### PR TITLE
Add app architecture docs for extension, webapp, and agent service

### DIFF
--- a/agent_service/ARCHITECTURE.md
+++ b/agent_service/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Agent Service Architecture
+
+## Purpose
+
+The FastAPI agent service receives normalized assignment payloads (plus optional PDF content), orchestrates LLM generation, and returns a structured study guide response.
+
+## Runtime Components
+
+- `app/main.py`: FastAPI entrypoint, route registration, legacy compatibility endpoints.
+- `app/api/v1/routes/runs.py`: Request handler wrapper for run execution.
+- `app/services/run_agent_service.py`: Request-level workflow orchestration.
+- `app/services/pdf_text_service.py`: PDF decode and text extraction.
+- `app/orchestrators/headstart_orchestrator.py`: LLM prompting, structured parsing, retry/fallback logic.
+- `app/clients/llm_client.py`: LLM client factory (NVIDIA via LangChain).
+- `app/schemas/*`: Pydantic request/response and shared models.
+
+## API Surface
+
+- `GET /health` (legacy)
+- `POST /run-agent` (legacy)
+- `GET /api/v1/health`
+- `POST /api/v1/runs`
+
+Both run endpoints share the same internal handler path through `handle_run_agent_request()`.
+
+## Module Boundaries
+
+- `api/v1/routes/*`: HTTP transport and error mapping only.
+- `services/*`: Workflow orchestration and cross-module coordination.
+- `orchestrators/*`: LLM-specific behavior and output shaping.
+- `schemas/*`: Input/output contract definitions.
+- `clients/*`: External provider initialization only.
+
+## Request Contract
+
+`RunAgentRequest`:
+
+- `assignment_uuid?: string`
+- `payload: Dict[str, Any]` (required)
+- `pdf_text?: string`
+- `pdf_files?: List[{ filename, base64_data }]`
+
+## Response Contract
+
+`RunAgentResponse`:
+
+- `description: string`
+- `keyRequirements: string[]`
+- `deliverables: string[]`
+- `milestones: { date, task }[]`
+- `studyPlan: { durationMin, focus }[]`
+- `risks: string[]`
+
+## End-to-End Call Flow
+
+1. Web app forwards request to `POST /run-agent` (or v1 route).
+2. Route calls `run_agent_workflow()` from `services/run_agent_service.py`.
+3. Service logs request metadata and calls `extract_all_pdf_text()`.
+4. PDF service:
+5. Decodes `pdf_files[*].base64_data`.
+6. Uses PyMuPDF (`fitz`) to extract per-page text.
+7. Merges extracted text with legacy `pdf_text`.
+8. Writes combined debug dump to `agent_service/pdf_extracted_text.txt`.
+9. Service calls `run_headstart_agent(payload, pdf_text)`.
+10. Orchestrator builds NVIDIA chat client and attempts:
+11. Structured output mode (`with_structured_output(RunAgentResponse)`).
+12. Fallback prompt-based generation with JSON repair/parsing heuristics.
+13. Service returns structured dictionary back through route layer.
+
+## LLM Orchestration Strategy
+
+- Primary mode: schema-bound structured output for reliable contract adherence.
+- Fallback mode: strict JSON prompt with retries (`MAX_RETRIES`) and parser repair.
+- Parsing safeguards: markdown fence stripping, quote normalization, trailing comma cleanup, control-character cleanup, key quoting heuristics.
+
+## Configuration and Dependencies
+
+- Required env var: `NVIDIA_API_KEY`.
+- Core dependencies: FastAPI, Pydantic, LangChain, NVIDIA LangChain endpoint client.
+- Optional but recommended: PyMuPDF for PDF extraction.
+
+## Failure Behavior
+
+- Missing `NVIDIA_API_KEY` raises runtime error.
+- PDF decode/extract failures are logged and skipped per file.
+- Route wrapper catches unhandled workflow exceptions and returns HTTP 500.
+- Parsing failures after all retries raise explicit runtime errors with diagnostics.

--- a/extension/ARCHITECTURE.md
+++ b/extension/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Extension Architecture
+
+## Purpose
+
+The Chrome MV3 extension detects Canvas assignment pages, extracts assignment data, stores normalized records in `chrome.storage.local`, and triggers Headstart AI runs through the web app API.
+
+## Runtime Components
+
+- `src/content/*`: Runs in Canvas pages. Detects page type, extracts assignment content, injects widget UI.
+- `src/background/*`: Runs in the MV3 service worker. Routes runtime messages, persists assignment records, and coordinates backend calls.
+- `src/storage/assignment-store.js`: Storage access layer for assignment records.
+- `src/clients/webapp-client.js`: HTTP client for web app endpoints (`/api/ingest-assignment`, `/api/run-agent`).
+- `src/shared/contracts/messages.js`: Message types shared across content and background contexts.
+
+## Module Boundaries
+
+- `content/detectors`: URL/page classification only.
+- `content/extractors`: DOM/API extraction only.
+- `content/injectors` and `content/ui`: UI injection only.
+- `background/handlers`: Message-specific persistence/update handling.
+- `background/workflows`: Multi-step orchestration, especially AI run flow.
+- `storage`: All `chrome.storage.local` reads/writes.
+- `clients`: All network calls from extension code.
+
+## Data Model
+
+- Assignment storage key format: `assignment::<courseId>::<assignmentId>`.
+- Core stored fields: `courseId`, `assignmentId`, `title`, `dueDate`, `descriptionText`, `rubric`, `userTimezone`, `pdfAttachments`, metadata (`detectedAt`, `status`, `url`).
+- Headstart payload is derived from stored assignment records via `buildHeadstartPayload`.
+
+## Flow 1: Detection and Extraction
+
+1. Content entrypoint `src/content/index.js` runs on matching Canvas URLs.
+2. `detectCanvasPage()` classifies page as single assignment vs assignment list.
+3. For single assignment pages:
+4. `runSingleAssignmentFlow()` sends `ASSIGNMENT_DETECTED` to background.
+5. `extractAssignmentData()` gathers normalized assignment fields.
+6. Content sends `ASSIGNMENT_DATA` with extracted data.
+7. `injectWidget()` renders the in-page widget.
+8. Background router `src/background/index.js` dispatches to:
+9. `handleAssignmentDetected()` -> `upsertDetectedAssignment()`.
+10. `handleAssignmentData()` -> `mergeExtractedAssignment()`.
+
+## Flow 2: Headstart Run Orchestration
+
+1. Content/widget sends `START_HEADSTART_RUN`.
+2. Background router calls `handleStartHeadstartRun()` (`background/workflows/headstart-run-workflow.js`).
+3. Workflow parses Canvas IDs from tab URL and loads stored assignment record.
+4. `buildHeadstartPayload()` normalizes due date/timezone flags and assignment details.
+5. Extension calls web app `/api/ingest-assignment` via `ingestAssignment()`.
+6. Extension calls web app `/api/run-agent` via `runAgent()`, including PDF attachments as base64.
+7. Background sends `HEADSTART_RESULT` or `HEADSTART_ERROR` back to the active tab.
+
+## Failure and Recovery Behavior
+
+- Unknown runtime messages are acknowledged with `{ status: "unknown" }`.
+- Missing Canvas assignment context or missing stored assignment record returns `HEADSTART_ERROR`.
+- Non-2xx backend responses throw in `webapp-client` and are surfaced as `HEADSTART_ERROR`.
+- Storage merges preserve earlier fields when partial extraction payloads are received.
+
+## External Dependencies
+
+- Chrome Extension APIs (`runtime`, `tabs`, `storage`, `action`).
+- Canvas LMS DOM/URL patterns.
+- Local web app API at `http://localhost:3000` by default.

--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -1,0 +1,68 @@
+# Web App Architecture
+
+## Purpose
+
+The Next.js web app serves two roles:
+
+- Student-facing UI (landing pages and dashboard views).
+- Backend-for-frontend API facade used by the extension, including forwarding AI run requests to the FastAPI agent service.
+
+## Runtime Components
+
+- `src/app/*`: App Router pages, layouts, and API routes.
+- `src/app/api/ingest-assignment/route.ts`: Accepts normalized assignment payload and returns `assignment_uuid`.
+- `src/app/api/run-agent/route.ts`: Proxies run requests to agent service.
+- `src/components/*`: UI component library and layout components.
+- `src/lib/data.ts`: Current demo/dashboard data source used by UI views.
+
+## Module Boundaries
+
+- `app/api/*`: Transport handlers (request parsing, logging, forwarding, response mapping).
+- UI pages (`app/page.tsx`, `app/dashboard/*`): Client rendering and interaction.
+- `lib/*`: Shared UI-side utilities and data helpers.
+- Agent-service integration is isolated to `app/api/run-agent/route.ts`.
+
+## API Surface
+
+- `POST /api/ingest-assignment`
+- Input: extension-normalized assignment payload.
+- Output: `{ ok: true, assignment_uuid }`.
+
+- `POST /api/run-agent`
+- Input: `{ assignment_uuid, payload, pdf_text?, pdf_files? }`.
+- Behavior: forwards request to `${AGENT_SERVICE_URL}/run-agent`.
+- Output: raw JSON body returned by agent service (or mapped error).
+
+## Flow 1: Ingest Assignment
+
+1. Extension background workflow calls `/api/ingest-assignment`.
+2. Route handler parses JSON body and logs assignment identifiers.
+3. Handler creates `assignment_uuid` with `crypto.randomUUID()`.
+4. Handler returns JSON acknowledgment with generated UUID.
+
+## Flow 2: Run Agent Proxy
+
+1. Extension calls `/api/run-agent` with assignment payload and optional PDF files.
+2. Route validates `AGENT_SERVICE_URL` presence.
+3. Route forwards request body to `${AGENT_SERVICE_URL}/run-agent`.
+4. Route reads upstream status/body and logs latency.
+5. On success, route returns upstream JSON body directly.
+6. On upstream failure, route returns 500 with error metadata.
+
+## UI Data Flow (Current State)
+
+- Dashboard pages call `fetchDashboardData()` from `src/lib/data.ts`.
+- The current dashboard data source is in-memory/demo data.
+- UI components are separated into layout and reusable primitives under `src/components`.
+
+## Configuration and Dependencies
+
+- Runtime: Next.js App Router on Node.js runtime for API routes.
+- Required env var: `AGENT_SERVICE_URL`.
+- Optional local default for extension integration: web app runs on `http://localhost:3000`.
+
+## Failure Behavior
+
+- Missing `AGENT_SERVICE_URL` returns `500` with explicit error.
+- Agent-service non-2xx response is mapped to `500` with `detail` containing upstream body excerpt.
+- Network errors during forward call surface as route failures.


### PR DESCRIPTION
## Summary
- add extension architecture documentation
- add webapp architecture documentation
- add agent service architecture documentation
- document module boundaries, data flow, and function-calling flow for each app

Closes #6