### PR TITLE
Group chat sessions by assignment name on /dashboard/chat page

### DIFF
--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -89,6 +89,15 @@ type ChatSessionListItemResponse = {
   }
 }
 
+type ChatSessionAssignmentGroup = {
+  groupKey: string
+  assignmentTitle: string
+  courseName: string | null
+  dueAtISO: string | null
+  latestUpdatedAt: number
+  sessions: ChatSessionListItemResponse[]
+}
+
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
 const THINK_OPEN_TAG = "<think>"
 const THINK_CLOSE_TAG = "</think>"
@@ -561,6 +570,58 @@ function DashboardChatPageContent() {
     })
     .filter((name) => name.length > 0)
   const createdAtText = formatDateTime(effectiveSession?.created_at)
+  const groupedSessionList = useMemo(() => {
+    const grouped = new Map<string, ChatSessionAssignmentGroup>()
+
+    for (const item of sessionList) {
+      const rawAssignmentTitle = (item.context.assignment_title || item.title || "").trim()
+      const assignmentTitle = rawAssignmentTitle || "(untitled assignment)"
+      const normalizedAssignmentTitle = assignmentTitle
+        .toLocaleLowerCase()
+        .replace(/\s+/g, " ")
+        .trim()
+      const incomingCourseName = item.context.course_name?.trim() || null
+      const groupKey =
+        normalizedAssignmentTitle && normalizedAssignmentTitle !== "(untitled assignment)"
+          ? normalizedAssignmentTitle
+          : `untitled::${item.assignment_uuid || item.session_id}`
+      const existingGroup = grouped.get(groupKey)
+
+      if (existingGroup) {
+        existingGroup.sessions.push(item)
+        existingGroup.latestUpdatedAt = Math.max(existingGroup.latestUpdatedAt, item.updated_at)
+        if (!existingGroup.courseName && incomingCourseName) {
+          existingGroup.courseName = incomingCourseName
+        } else if (
+          existingGroup.courseName &&
+          incomingCourseName &&
+          existingGroup.courseName !== "Multiple courses" &&
+          existingGroup.courseName.toLocaleLowerCase() !== incomingCourseName.toLocaleLowerCase()
+        ) {
+          existingGroup.courseName = "Multiple courses"
+        }
+        if (!existingGroup.dueAtISO && item.context.due_at_iso) {
+          existingGroup.dueAtISO = item.context.due_at_iso
+        }
+      } else {
+        grouped.set(groupKey, {
+          groupKey,
+          assignmentTitle,
+          courseName: incomingCourseName,
+          dueAtISO: item.context.due_at_iso,
+          latestUpdatedAt: item.updated_at,
+          sessions: [item],
+        })
+      }
+    }
+
+    return Array.from(grouped.values())
+      .map((group) => ({
+        ...group,
+        sessions: group.sessions.slice().sort((left, right) => right.updated_at - left.updated_at),
+      }))
+      .sort((left, right) => right.latestUpdatedAt - left.latestUpdatedAt)
+  }, [sessionList])
 
   const rawGuideMarkdown = useMemo(() => {
     if (!effectiveSession) return ""
@@ -737,39 +798,53 @@ function DashboardChatPageContent() {
                     variants={CHAT_LIST_CONTAINER_VARIANTS}
                     initial={reduceMotion ? false : "hidden"}
                     animate={reduceMotion ? undefined : "show"}
-                    className="space-y-2"
+                    className="space-y-3"
                   >
-                    {sessionList.map((item) => {
-                      const updatedAtText = formatDateTime(item.updated_at) || "-"
-                      const dueAtText = formatDateTime(item.context.due_at_iso)
-
+                    {groupedSessionList.map((group) => {
                       return (
-                        <motion.button
-                          key={item.session_id}
-                          type="button"
+                        <motion.section
+                          key={group.groupKey}
                           variants={CHAT_LIST_ITEM_VARIANTS}
-                          onClick={() => handleOpenSession(item.session_id)}
-                          className="w-full rounded-xl border border-border/60 bg-background/50 p-3 text-left transition-colors hover:border-brand-blue/40 hover:bg-brand-blue/5"
+                          className="space-y-2"
                         >
-                          <div className="flex flex-wrap items-start justify-between gap-2">
-                            <div className="min-w-0">
-                              <p className="truncate text-sm font-semibold text-foreground">
-                                {item.context.assignment_title || item.title}
-                              </p>
-                              <p className="truncate text-xs text-muted-foreground">
-                                {item.context.course_name || "Unknown course"}
-                              </p>
-                            </div>
-                            <Badge variant="outline" className="capitalize">
-                              {item.status}
-                            </Badge>
+                          <p className="truncate text-sm font-semibold text-foreground">
+                            {group.assignmentTitle}
+                          </p>
+
+                          <div className="space-y-2">
+                            {group.sessions.map((item) => {
+                              const updatedAtText = formatDateTime(item.updated_at) || "-"
+                              const normalizedTitle = item.title.trim()
+                              const sessionLabel =
+                                normalizedTitle && normalizedTitle !== group.assignmentTitle
+                                  ? normalizedTitle
+                                  : "Chat session"
+
+                              return (
+                                <motion.button
+                                  key={item.session_id}
+                                  type="button"
+                                  variants={CHAT_LIST_ITEM_VARIANTS}
+                                  onClick={() => handleOpenSession(item.session_id)}
+                                  className="w-full rounded-lg border border-border/60 bg-background/60 p-3 text-left transition-colors hover:border-brand-blue/40 hover:bg-brand-blue/5"
+                                >
+                                  <div className="flex flex-wrap items-start justify-between gap-2">
+                                    <p className="truncate text-sm font-medium text-foreground">
+                                      {sessionLabel}
+                                    </p>
+                                    <Badge variant="outline" className="capitalize">
+                                      {item.status}
+                                    </Badge>
+                                  </div>
+                                  <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                                    <span>Updated {updatedAtText}</span>
+                                    <span>Attachments: {item.context.attachment_count}</span>
+                                  </div>
+                                </motion.button>
+                              )
+                            })}
                           </div>
-                          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                            <span>Updated {updatedAtText}</span>
-                            {dueAtText ? <span>Due {dueAtText}</span> : null}
-                            <span>Attachments: {item.context.attachment_count}</span>
-                          </div>
-                        </motion.button>
+                        </motion.section>
                       )
                     })}
                   </motion.div>

--- a/webapp/src/app/dashboard/page.tsx
+++ b/webapp/src/app/dashboard/page.tsx
@@ -218,8 +218,7 @@ export default function Dashboard() {
   return (
     <motion.div variants={container} initial="hidden" animate="show" className="space-y-4">
       <motion.div variants={item}>
-        <Card className="relative overflow-hidden border-border/60 bg-gradient-to-br from-background via-background to-muted/35 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.7)]">
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-sky-500/15 via-emerald-400/10 to-transparent dark:from-sky-500/10 dark:via-emerald-500/10" />
+        <Card className="relative overflow-hidden border-border/60 bg-card/95 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.7)]">
           <CardContent className="relative space-y-4 px-4 py-3.5 sm:px-5">
             <div className="flex min-h-0 flex-wrap items-start justify-between gap-x-3 gap-y-2">
               <div className="space-y-0.5">


### PR DESCRIPTION
This pull request refactors the chat session list in the dashboard to group sessions by assignment, improving organization and readability. It introduces a new grouping logic, updates the UI to display grouped sessions, and makes minor visual adjustments to card backgrounds.

**Chat session grouping and UI improvements:**

* Added a new type `ChatSessionAssignmentGroup` and logic to group chat sessions by assignment title and course, including handling multiple courses and untitled assignments. (`webapp/src/app/dashboard/chat/page.tsx`) [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR92-R100) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR573-R624)
* Updated the chat session list UI to display sessions grouped under their assignment, showing assignment titles as section headers and session details within each group. (`webapp/src/app/dashboard/chat/page.tsx`)

**Visual tweaks:**

* Changed the dashboard card background to use `bg-card/95` and removed the gradient overlay for a cleaner look. (`webapp/src/app/dashboard/page.tsx`)