### PR TITLE
Add timestamp formatting and update session activity for chat

### DIFF
--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -2,7 +2,7 @@
 
 import { type FormEvent, type KeyboardEvent as ReactKeyboardEvent, Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { format } from "date-fns"
+import { format, isSameDay } from "date-fns"
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
 import { LoaderCircle, SendHorizontal, Trash2 } from "lucide-react"
 import ReactMarkdown, { type Components } from "react-markdown"
@@ -278,6 +278,9 @@ function formatMessageTimestamp(value: string | null | undefined) {
   if (!value) return null
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return null
+  if (!isSameDay(date, new Date())) {
+    return format(date, "MMM d, yyyy hh:mm a")
+  }
   return format(date, "hh:mm a")
 }
 

--- a/webapp/src/lib/chat-repository.ts
+++ b/webapp/src/lib/chat-repository.ts
@@ -88,6 +88,12 @@ type DbChatMessageListPreview = {
   content_text: string;
 };
 
+type DbChatMessageTimestampPreview = {
+  session_id: string;
+  message_index: number;
+  created_at: string;
+};
+
 type DbHeadstartRun = {
   id: string;
   assignment_uuid: string;
@@ -1133,18 +1139,37 @@ export async function listPersistedChatSessionsForUser(
   }
 
   const sessionIds = sessions.map((session) => session.id);
-  const userMessages =
+  const [userMessages, latestMessageRows] =
     sessionIds.length > 0
-      ? await selectMany<DbChatMessageListPreview>({
-          table: "chat_messages",
-          query: {
-            session_id: inList(sessionIds),
-            sender_role: eq("user"),
-            select: "session_id,message_index,content_text",
-            order: "session_id.asc,message_index.desc",
-          },
-        })
-      : [];
+      ? await Promise.all([
+          selectMany<DbChatMessageListPreview>({
+            table: "chat_messages",
+            query: {
+              session_id: inList(sessionIds),
+              sender_role: eq("user"),
+              select: "session_id,message_index,content_text",
+              order: "session_id.asc,message_index.desc",
+            },
+          }),
+          selectMany<DbChatMessageTimestampPreview>({
+            table: "chat_messages",
+            query: {
+              session_id: inList(sessionIds),
+              select: "session_id,message_index,created_at",
+              order: "session_id.asc,message_index.desc",
+            },
+          }),
+        ])
+      : [[], []];
+
+  const latestMessageCreatedAtBySessionId = new Map<string, string>();
+  for (const message of latestMessageRows) {
+    if (latestMessageCreatedAtBySessionId.has(message.session_id)) {
+      continue;
+    }
+    latestMessageCreatedAtBySessionId.set(message.session_id, message.created_at);
+  }
+
   const lastUserMessageBySessionId = new Map<string, string | null>();
   for (const message of userMessages) {
     if (lastUserMessageBySessionId.has(message.session_id)) {
@@ -1188,45 +1213,57 @@ export async function listPersistedChatSessionsForUser(
       : [];
   const snapshotById = new Map(snapshots.map((snapshot) => [snapshot.id, snapshot]));
 
-  return sessions.map((session) => {
-    const ingest = ingestByAssignmentUuid.get(session.assignment_uuid);
-    const snapshot = ingest
-      ? snapshotById.get(ingest.assignment_snapshot_id)
-      : undefined;
-    const payload = sanitizePayloadForResponse(
-      asObject(snapshot?.raw_payload) as AssignmentPayload,
-    );
-    const attachmentCount = Array.isArray(payload.pdfAttachments)
-      ? payload.pdfAttachments.length
-      : 0;
-    const assignmentTitle =
-      toOptionalString(snapshot?.title) ??
-      toOptionalString(payload.title) ??
-      toOptionalString(session.title) ??
-      "(untitled assignment)";
+  return sessions
+    .map((session) => {
+      const ingest = ingestByAssignmentUuid.get(session.assignment_uuid);
+      const snapshot = ingest
+        ? snapshotById.get(ingest.assignment_snapshot_id)
+        : undefined;
+      const payload = sanitizePayloadForResponse(
+        asObject(snapshot?.raw_payload) as AssignmentPayload,
+      );
+      const attachmentCount = Array.isArray(payload.pdfAttachments)
+        ? payload.pdfAttachments.length
+        : 0;
+      const assignmentTitle =
+        toOptionalString(snapshot?.title) ??
+        toOptionalString(payload.title) ??
+        toOptionalString(session.title) ??
+        "(untitled assignment)";
+      const createdAt = toEpoch(session.created_at);
+      const latestMessageCreatedAt = latestMessageCreatedAtBySessionId.get(session.id);
+      const updatedAt = latestMessageCreatedAt
+        ? toEpoch(latestMessageCreatedAt)
+        : createdAt;
 
-    return {
-      sessionId: session.id,
-      assignmentUuid: session.assignment_uuid,
-      title: toOptionalString(session.title) ?? assignmentTitle,
-      lastUserMessage: lastUserMessageBySessionId.get(session.id) ?? null,
-      status: session.status,
-      createdAt: toEpoch(session.created_at),
-      updatedAt: toEpoch(session.updated_at),
-      context: {
-        assignmentRecordId: toOptionalString(snapshot?.assignment_id),
-        assignmentTitle,
-        courseName: toOptionalString(payload.courseName),
-        courseId: toOptionalString(payload.courseId),
-        assignmentId: toOptionalString(payload.assignmentId),
-        assignmentUrl: toOptionalString(payload.url),
-        dueAtISO:
-          toOptionalString(payload.dueAtISO) ??
-          toOptionalString(snapshot?.due_at),
-        attachmentCount,
-      },
-    };
-  });
+      return {
+        sessionId: session.id,
+        assignmentUuid: session.assignment_uuid,
+        title: toOptionalString(session.title) ?? assignmentTitle,
+        lastUserMessage: lastUserMessageBySessionId.get(session.id) ?? null,
+        status: session.status,
+        createdAt,
+        updatedAt,
+        context: {
+          assignmentRecordId: toOptionalString(snapshot?.assignment_id),
+          assignmentTitle,
+          courseName: toOptionalString(payload.courseName),
+          courseId: toOptionalString(payload.courseId),
+          assignmentId: toOptionalString(payload.assignmentId),
+          assignmentUrl: toOptionalString(payload.url),
+          dueAtISO:
+            toOptionalString(payload.dueAtISO) ??
+            toOptionalString(snapshot?.due_at),
+          attachmentCount,
+        },
+      };
+    })
+    .sort((left, right) => {
+      if (right.updatedAt !== left.updatedAt) {
+        return right.updatedAt - left.updatedAt;
+      }
+      return right.createdAt - left.createdAt;
+    });
 }
 
 export async function findLatestExistingGuideForAssignment(input: {
@@ -1665,6 +1702,25 @@ export async function createChatMessage(input: {
       metadata: input.metadata ?? {},
     },
   });
+
+  // Best-effort touch so chat session lists reflect latest message activity.
+  try {
+    await supabaseTableRequest<null>({
+      table: "chat_sessions",
+      method: "PATCH",
+      query: {
+        id: eq(input.sessionId),
+      },
+      headers: {
+        Prefer: "return=minimal",
+      },
+      body: {
+        updated_at: nowIso(),
+      },
+    });
+  } catch {
+    // Ignore non-critical touch failures; message persistence already succeeded.
+  }
 
   return toMessageDto(row);
 }


### PR DESCRIPTION
This pull request introduces improvements to how chat message timestamps are displayed and how chat sessions are sorted and updated in the dashboard. The changes enhance the user experience by showing more relevant timestamps for messages and ensuring session lists reflect recent activity.

**User-facing improvements:**

* Added display of formatted timestamps for each chat message in the chat UI, showing either the time or full date depending on whether the message is from today (`webapp/src/app/dashboard/chat/page.tsx`). [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR277-R286) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1211) [[3]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1261-R1271)

**Backend and data handling:**

* Updated the chat session listing logic to use the timestamp of the latest message for sorting and for the `updatedAt` field, making session lists more accurately reflect recent activity (`webapp/src/lib/chat-repository.ts`). [[1]](diffhunk://#diff-9572c45b81636e25a14526652aa92a149240edd9ca6de56d1614f8c6520540e7L1136-R1172) [[2]](diffhunk://#diff-9572c45b81636e25a14526652aa92a149240edd9ca6de56d1614f8c6520540e7R1233-R1246) [[3]](diffhunk://#diff-9572c45b81636e25a14526652aa92a149240edd9ca6de56d1614f8c6520540e7R1260-R1265)
* Added a best-effort "touch" operation to update the `updated_at` field of a chat session whenever a new message is created, so session lists remain up-to-date (`webapp/src/lib/chat-repository.ts`).

**Type and query updates:**

* Introduced a new type `DbChatMessageTimestampPreview` to support fetching message timestamps for session sorting (`webapp/src/lib/chat-repository.ts`).