### PR TITLE
Implement versioning and regeneration for study guides

### DIFF
--- a/webapp/src/app/api/chat-session/[sessionId]/guide-versions/[versionNumber]/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/guide-versions/[versionNumber]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { assertSessionOwnership, getGuideVersionContent } from "@/lib/chat-repository";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ sessionId: string; versionNumber: string }> },
+) {
+  const { sessionId, versionNumber: versionNumberRaw } = await params;
+
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const versionNumber = parseInt(versionNumberRaw, 10);
+  if (!Number.isFinite(versionNumber) || versionNumber < 1) {
+    return NextResponse.json({ error: "Invalid version number" }, { status: 400 });
+  }
+
+  const session = await assertSessionOwnership(sessionId, userId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const contentText = await getGuideVersionContent(sessionId, versionNumber);
+  if (contentText === null) {
+    return NextResponse.json({ error: "Guide version not found" }, { status: 404 });
+  }
+
+  const response = NextResponse.json({ ok: true, version_number: versionNumber, content_text: contentText });
+  if (resolvedUser?.refreshedSession) {
+    applyAuthCookies(response, resolvedUser.refreshedSession);
+  }
+  return response;
+}

--- a/webapp/src/app/api/chat-session/[sessionId]/guide-versions/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/guide-versions/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { assertSessionOwnership, listGuideVersions } from "@/lib/chat-repository";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const session = await assertSessionOwnership(sessionId, userId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const versions = await listGuideVersions(sessionId);
+
+  const response = NextResponse.json({ ok: true, versions });
+  if (resolvedUser?.refreshedSession) {
+    applyAuthCookies(response, resolvedUser.refreshedSession);
+  }
+  return response;
+}

--- a/webapp/src/app/api/chat-session/[sessionId]/messages/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/messages/route.ts
@@ -8,7 +8,6 @@ import { startFollowupChatRun } from "@/lib/chat-session-runner";
 import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
 
 export const runtime = "nodejs";
-const CHAT_THINKING_MODES = new Set(["normal", "thinking"]);
 
 function isGuideReady(sessionStatus: string, runtimeStatus: string | undefined) {
   return sessionStatus === "completed" || runtimeStatus === "completed";
@@ -30,9 +29,6 @@ export async function POST(
   const resolvedUser = await resolveRequestUser(req);
   const userId = resolvedUser?.user.id ?? "";
   const content = typeof body?.content === "string" ? body.content.trim() : "";
-  const thinkingModeRaw =
-    typeof body?.thinking_mode === "string" ? body.thinking_mode.trim() : "normal";
-  const thinkingMode = thinkingModeRaw.toLowerCase();
   const rawAttachments = Array.isArray(body?.attachments) ? body.attachments : [];
   const attachments: ChatAttachment[] = rawAttachments
     .slice(0, 3)
@@ -55,13 +51,6 @@ export async function POST(
   if (!content && attachments.length === 0) {
     return NextResponse.json(
       { error: "content or attachments are required" },
-      { status: 400 },
-    );
-  }
-
-  if (!CHAT_THINKING_MODES.has(thinkingMode)) {
-    return NextResponse.json(
-      { error: "thinking_mode must be 'normal' or 'thinking'" },
       { status: 400 },
     );
   }
@@ -97,7 +86,6 @@ export async function POST(
       format: "markdown",
       metadata: {
         source: "dashboard",
-        thinking_mode: thinkingMode,
         ...(attachments.length > 0 ? { attachments } : {}),
       },
     });
@@ -109,7 +97,6 @@ export async function POST(
       format: "markdown",
       metadata: {
         streaming: true,
-        thinking_mode: thinkingMode,
       },
     });
 
@@ -120,7 +107,6 @@ export async function POST(
       sessionId,
       assistantMessageId: assistantMessage.id,
       userMessageContent: content,
-      thinkingMode: thinkingMode === "thinking" ? "thinking" : "normal",
       requestUrl: req.url,
       attachments,
     });

--- a/webapp/src/app/api/chat-session/[sessionId]/regenerate-guide/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/regenerate-guide/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import {
+  assertSessionOwnership,
+  createChatMessage,
+  getNextGuideVersionNumber,
+} from "@/lib/chat-repository";
+import { emitChatMessageCreated, getRuntimeSession } from "@/lib/chat-runtime-store";
+import { startGuideRegeneration } from "@/lib/chat-session-runner";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const session = await assertSessionOwnership(sessionId, userId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const runtimeSession = getRuntimeSession(sessionId);
+  const effectiveStatus = runtimeSession?.status ?? session.status;
+
+  if (effectiveStatus === "running" || effectiveStatus === "queued") {
+    return NextResponse.json(
+      { error: "Guide generation or regeneration is already in progress" },
+      { status: 409 },
+    );
+  }
+
+  if (effectiveStatus !== "completed") {
+    return NextResponse.json(
+      { error: "Guide must be completed before regenerating" },
+      { status: 409 },
+    );
+  }
+
+  const versionNumber = await getNextGuideVersionNumber(sessionId);
+
+  try {
+    // Create an empty assistant message that will be streamed into
+    const assistantMessage = await createChatMessage({
+      sessionId,
+      role: "assistant",
+      content: "",
+      format: "markdown",
+      metadata: {
+        streaming: true,
+        guide_version: versionNumber,
+      },
+    });
+
+    emitChatMessageCreated(sessionId, assistantMessage);
+
+    startGuideRegeneration({
+      sessionId,
+      assistantMessageId: assistantMessage.id,
+      versionNumber,
+      requestUrl: req.url,
+    });
+
+    const response = NextResponse.json({
+      ok: true,
+      version_number: versionNumber,
+      assistant_message_id: assistantMessage.id,
+    });
+    if (resolvedUser?.refreshedSession) {
+      applyAuthCookies(response, resolvedUser.refreshedSession);
+    }
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      { error: "Unable to start guide update", detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -4,7 +4,7 @@ import { type ChangeEvent, type FormEvent, type KeyboardEvent as ReactKeyboardEv
 import { useRouter, useSearchParams } from "next/navigation"
 import { format } from "date-fns"
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion"
-import { Brain, LoaderCircle, Paperclip, SendHorizontal, Trash2, X } from "lucide-react"
+import { LoaderCircle, Paperclip, RefreshCw, SendHorizontal, Trash2, X } from "lucide-react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
@@ -109,6 +109,13 @@ type ChatSessionAssignmentGroup = {
   dueAtISO: string | null
   latestUpdatedAt: number
   sessions: ChatSessionListItemResponse[]
+}
+
+type GuideVersionMeta = {
+  version_number: number
+  source: string
+  content_length: number
+  created_at: string
 }
 
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
@@ -297,7 +304,6 @@ function DashboardChatPageContent() {
   const [errorText, setErrorText] = useState<string | null>(null)
   const [draft, setDraft] = useState("")
   const [isSending, setIsSending] = useState(false)
-  const [isThinkingModeEnabled, setIsThinkingModeEnabled] = useState(false)
   const [showProgressPanel, setShowProgressPanel] = useState(false)
   const [calendarProposals, setCalendarProposals] = useState<
     Map<string, { assignmentId: string; sessions: Array<{ start_iso: string; end_iso: string; focus: string; priority: "high" | "medium" | "low" }> }>
@@ -307,6 +313,8 @@ function DashboardChatPageContent() {
   const [isContextDialogOpen, setIsContextDialogOpen] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<File[]>([])
   const [fileError, setFileError] = useState<string | null>(null)
+  const [guideVersions, setGuideVersions] = useState<GuideVersionMeta[]>([])
+  const [isRegenerating, setIsRegenerating] = useState(false)
   const threadContainerRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -330,6 +338,14 @@ function DashboardChatPageContent() {
       top: viewport.scrollHeight,
       behavior,
     })
+  }
+
+  function scrollToGuideVersion(versionNumber: number) {
+    const viewport = getThreadViewport()
+    if (!viewport) return
+    const target = viewport.querySelector<HTMLElement>(`[data-guide-version="${versionNumber}"]`)
+    if (!target) return
+    target.scrollIntoView({ behavior: "smooth", block: "start" })
   }
 
   function isNearBottom(threshold = 150) {
@@ -647,6 +663,29 @@ function DashboardChatPageContent() {
       eventSource.close()
     }
   }, [sessionId])
+
+  // Fetch guide versions whenever the session completes (or on initial load of a completed session)
+  useEffect(() => {
+    if (!sessionId || !session || session.session_id !== sessionId) return
+    if (session.status !== "completed") return
+
+    let isDisposed = false
+    fetch(`/api/chat-session/${encodeURIComponent(sessionId)}/guide-versions`, {
+      cache: "no-store",
+    })
+      .then((res) => res.ok ? res.json() : Promise.reject(new Error(`${res.status}`)))
+      .then((body: { versions?: GuideVersionMeta[] }) => {
+        if (!isDisposed && Array.isArray(body.versions)) {
+          setGuideVersions(body.versions)
+          setIsRegenerating(false)
+        }
+      })
+      .catch(() => {
+        // Non-critical — export button just won't show version picker
+      })
+    return () => { isDisposed = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, session?.status])
 
   // Restore calendar proposals from persisted message metadata on page load / session change
   useEffect(() => {
@@ -1095,6 +1134,28 @@ function DashboardChatPageContent() {
     )
   }
 
+  async function handleRegenerateGuide() {
+    if (!sessionId || !effectiveSession || isRegenerating) return
+    setIsRegenerating(true)
+    try {
+      const res = await fetch(
+        `/api/chat-session/${encodeURIComponent(sessionId)}/regenerate-guide`,
+        { method: "POST" },
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string }
+        setErrorText(body.error ?? `Regeneration failed (${res.status})`)
+        setIsRegenerating(false)
+      }
+      // On success: the SSE stream will push session.update events that stream
+      // the new guide into the guide panel. isRegenerating resets when the
+      // guide-versions refetch fires (on status → completed).
+    } catch {
+      setErrorText("Failed to start guide regeneration.")
+      setIsRegenerating(false)
+    }
+  }
+
   async function handleSend(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const text = draft.trim()
@@ -1137,7 +1198,6 @@ function DashboardChatPageContent() {
           },
           body: JSON.stringify({
             content: text,
-            thinking_mode: isThinkingModeEnabled ? "thinking" : "normal",
             ...(uploadedAttachments.length > 0 ? { attachments: uploadedAttachments } : {}),
           }),
         },
@@ -1343,6 +1403,7 @@ function DashboardChatPageContent() {
                   {hasGuideContent ? (
                     <motion.div
                       key="guide-body"
+                      data-guide-version={1}
                       initial={reduceMotion ? false : { opacity: 0, y: 10 }}
                       animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                       transition={reduceMotion ? undefined : { duration: 0.35, ease: EASE_OUT }}
@@ -1367,8 +1428,14 @@ function DashboardChatPageContent() {
                   const proposal = message.sender_role === "assistant"
                     ? calendarProposals.get(message.id)
                     : undefined
+                  const guideVersionNum = typeof message.metadata?.guide_version === "number"
+                    ? message.metadata.guide_version
+                    : null
                   return (
-                    <div key={message.id}>
+                    <div
+                      key={message.id}
+                      {...(guideVersionNum !== null ? { "data-guide-version": guideVersionNum } : {})}
+                    >
                       <ChatMessageBubble
                         message={message}
                         isLatestStreamingAssistant={
@@ -1431,6 +1498,8 @@ function DashboardChatPageContent() {
                   guideMarkdown={guideMarkdown}
                   assignmentTitle={payload?.title}
                   courseName={payload?.courseName}
+                  versions={guideVersions}
+                  sessionId={sessionId}
                 />
               </div>
             )}
@@ -1477,17 +1546,6 @@ function DashboardChatPageContent() {
                       <p className="px-3 pt-1 text-[12px] text-destructive">{fileError}</p>
                     )}
                     <div className="flex items-end gap-2 px-2 py-2">
-                      <Button
-                        type="button"
-                        variant={isThinkingModeEnabled ? "secondary" : "ghost"}
-                        aria-pressed={isThinkingModeEnabled}
-                        disabled={isSending}
-                        onClick={() => setIsThinkingModeEnabled((previous) => !previous)}
-                        className="h-9 shrink-0 rounded-full px-3 text-xs font-medium"
-                      >
-                        <Brain className="mr-1.5 h-3.5 w-3.5" />
-                        {isThinkingModeEnabled ? "Thinking On" : "Thinking Off"}
-                      </Button>
                       <input
                         ref={fileInputRef}
                         type="file"
@@ -1522,6 +1580,19 @@ function DashboardChatPageContent() {
                         placeholder="Ask a follow-up question..."
                         className="min-h-10 max-h-40 w-full resize-none overflow-y-auto border-0 bg-transparent px-3 py-2.5 text-sm outline-none placeholder:text-muted-foreground"
                       />
+                      {hasGuideContent && !isGuideStreaming && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          disabled={isSending || isRegenerating}
+                          onClick={handleRegenerateGuide}
+                          className="h-9 shrink-0 rounded-full px-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+                          title="Update guide based on current chat context"
+                        >
+                          <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isRegenerating ? "animate-spin" : ""}`} />
+                          {isRegenerating ? "Updating…" : "Update Guide"}
+                        </Button>
+                      )}
                       <Button
                         type="submit"
                         variant="ghost"
@@ -1541,6 +1612,39 @@ function DashboardChatPageContent() {
             </div>
           </div>
         </motion.div>
+
+        {/* Guide version timeline — vertical timeline column to the right of chat */}
+        {guideVersions.length > 0 && (
+          <div className="ml-2 flex flex-col items-center pt-3 self-start sticky top-0">
+            {guideVersions.map((v, index) => (
+              <div key={v.version_number} className="flex flex-col items-center">
+                {/* Connector line above (except first) */}
+                {index > 0 && (
+                  <div className="w-px h-6 bg-gradient-to-b from-border/80 to-border/40" />
+                )}
+                <button
+                  type="button"
+                  onClick={() => scrollToGuideVersion(v.version_number)}
+                  className={[
+                    "relative h-9 w-9 rounded-full border text-[11px] font-semibold transition-all duration-200",
+                    "bg-background shadow-sm",
+                    "border-border/70 text-muted-foreground",
+                    "hover:border-brand-blue/50 hover:text-brand-blue",
+                    "hover:shadow-[0_0_0_3px_rgba(0,81,186,0.12),0_2px_10px_rgba(0,81,186,0.20)]",
+                    "hover:bg-brand-blue/10",
+                  ].join(" ")}
+                  title={`v${v.version_number} — ${v.source === "initial_run" ? "Initial guide" : "Regenerated"}`}
+                >
+                  v{v.version_number}
+                </button>
+                {/* Connector line below (except last) */}
+                {index < guideVersions.length - 1 && (
+                  <div className="w-px h-6 bg-gradient-to-b from-border/40 to-border/80" />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </motion.div>
 
       <Dialog open={isContextDialogOpen} onOpenChange={setIsContextDialogOpen}>

--- a/webapp/src/components/chat/guide-export-button.tsx
+++ b/webapp/src/components/chat/guide-export-button.tsx
@@ -2,12 +2,22 @@
 
 import { useState } from "react"
 import { FileText, FileDown } from "lucide-react"
+import { format } from "date-fns"
 import { Button } from "@/components/ui/button"
+
+type GuideVersionMeta = {
+  version_number: number
+  source: string
+  content_length: number
+  created_at: string
+}
 
 type GuideExportButtonProps = {
   guideMarkdown: string
   assignmentTitle?: string
   courseName?: string
+  versions?: GuideVersionMeta[]
+  sessionId?: string
 }
 
 function slugify(text: string): string {
@@ -23,72 +33,126 @@ function buildFilename(
   assignmentTitle: string | undefined,
   courseName: string | undefined,
   ext: "md" | "pdf",
+  versionSuffix?: string,
 ): string {
   const parts: string[] = []
   if (courseName) parts.push(slugify(courseName))
   parts.push(assignmentTitle ? slugify(assignmentTitle) : "Guide")
   parts.push("Headstart_Guide")
+  if (versionSuffix) parts.push(versionSuffix)
   return `${parts.join("_")}.${ext}`
 }
 
-export function GuideExportButton({ guideMarkdown, assignmentTitle, courseName }: GuideExportButtonProps) {
+function formatVersionDate(isoString: string) {
+  try {
+    return format(new Date(isoString), "MMM d, yyyy")
+  } catch {
+    return isoString
+  }
+}
+
+async function printMarkdownAsPdf(markdown: string, filename: string) {
+  const { marked } = await import("marked")
+  const html = await marked.parse(markdown)
+
+  const iframe = document.createElement("iframe")
+  iframe.style.cssText = "position:fixed;top:-9999px;left:-9999px;width:0;height:0;border:none"
+  document.body.appendChild(iframe)
+
+  const iframeDoc = iframe.contentDocument!
+  iframeDoc.open()
+  iframeDoc.write(`<!DOCTYPE html><html><head>
+    <title>${filename}</title>
+    <style>
+      body{font-family:system-ui,sans-serif;font-size:14px;line-height:1.6;color:#111;padding:24px;margin:0}
+      h1{font-size:22px;font-weight:600;margin:20px 0 8px}
+      h2{font-size:18px;font-weight:600;margin:18px 0 6px}
+      h3{font-size:16px;font-weight:600;margin:14px 0 6px}
+      p{margin:8px 0}
+      ul,ol{padding-left:20px;margin:8px 0}
+      li{margin:4px 0}
+      table{border-collapse:collapse;width:100%;margin:12px 0}
+      th,td{border:1px solid #ccc;padding:6px 10px;text-align:left;font-size:13px}
+      th{background:#f3f3f3;font-weight:600}
+      tr:nth-child(even){background:#fafafa}
+      code{background:#f0f0f0;border-radius:3px;padding:1px 4px;font-size:13px}
+      pre{background:#f0f0f0;border-radius:4px;padding:12px;overflow:auto;font-size:13px}
+      blockquote{border-left:3px solid #ccc;margin:8px 0;padding-left:12px;color:#555}
+      a{color:#2563eb}
+      hr{border:none;border-top:1px solid #e0e0e0;margin:16px 0}
+      @media print{body{padding:0}}
+    </style>
+  </head><body>${html}</body></html>`)
+  iframeDoc.close()
+
+  setTimeout(() => {
+    iframe.contentWindow!.print()
+    setTimeout(() => document.body.removeChild(iframe), 1000)
+  }, 250)
+}
+
+function downloadMarkdown(markdown: string, filename: string) {
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function GuideExportButton({
+  guideMarkdown,
+  assignmentTitle,
+  courseName,
+  versions = [],
+  sessionId,
+}: GuideExportButtonProps) {
   const [open, setOpen] = useState(false)
+  const [loadingVersion, setLoadingVersion] = useState<number | null>(null)
 
-  function exportMarkdown() {
-    const blob = new Blob([guideMarkdown], { type: "text/markdown;charset=utf-8" })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement("a")
-    a.href = url
-    a.download = buildFilename(assignmentTitle, courseName, "md")
-    a.click()
-    URL.revokeObjectURL(url)
+  const hasMultipleVersions = versions.length > 1
+  const latestVersion = versions.length > 0 ? versions[versions.length - 1] : null
+  const olderVersions = versions.length > 1 ? versions.slice(0, -1).reverse() : []
+
+  function exportCurrentMarkdown() {
+    const suffix = latestVersion ? `v${latestVersion.version_number}` : undefined
+    downloadMarkdown(guideMarkdown, buildFilename(assignmentTitle, courseName, "md", suffix))
     setOpen(false)
   }
 
-  async function exportPdf() {
+  async function exportCurrentPdf() {
     setOpen(false)
-    const { marked } = await import("marked")
-    const html = await marked.parse(guideMarkdown)
-    const filename = buildFilename(assignmentTitle, courseName, "pdf")
-
-    // Use the browser's native print-to-PDF. This avoids html2canvas entirely,
-    // which cannot parse oklch()/lab() colors used by the app's CSS theme.
-    const iframe = document.createElement("iframe")
-    iframe.style.cssText = "position:fixed;top:-9999px;left:-9999px;width:0;height:0;border:none"
-    document.body.appendChild(iframe)
-
-    const iframeDoc = iframe.contentDocument!
-    iframeDoc.open()
-    iframeDoc.write(`<!DOCTYPE html><html><head>
-      <title>${filename}</title>
-      <style>
-        body{font-family:system-ui,sans-serif;font-size:14px;line-height:1.6;color:#111;padding:24px;margin:0}
-        h1{font-size:22px;font-weight:600;margin:20px 0 8px}
-        h2{font-size:18px;font-weight:600;margin:18px 0 6px}
-        h3{font-size:16px;font-weight:600;margin:14px 0 6px}
-        p{margin:8px 0}
-        ul,ol{padding-left:20px;margin:8px 0}
-        li{margin:4px 0}
-        table{border-collapse:collapse;width:100%;margin:12px 0}
-        th,td{border:1px solid #ccc;padding:6px 10px;text-align:left;font-size:13px}
-        th{background:#f3f3f3;font-weight:600}
-        tr:nth-child(even){background:#fafafa}
-        code{background:#f0f0f0;border-radius:3px;padding:1px 4px;font-size:13px}
-        pre{background:#f0f0f0;border-radius:4px;padding:12px;overflow:auto;font-size:13px}
-        blockquote{border-left:3px solid #ccc;margin:8px 0;padding-left:12px;color:#555}
-        a{color:#2563eb}
-        hr{border:none;border-top:1px solid #e0e0e0;margin:16px 0}
-        @media print{body{padding:0}}
-      </style>
-    </head><body>${html}</body></html>`)
-    iframeDoc.close()
-
-    // Small delay to let the iframe render before printing
-    setTimeout(() => {
-      iframe.contentWindow!.print()
-      setTimeout(() => document.body.removeChild(iframe), 1000)
-    }, 250)
+    const suffix = latestVersion ? `v${latestVersion.version_number}` : undefined
+    await printMarkdownAsPdf(guideMarkdown, buildFilename(assignmentTitle, courseName, "pdf", suffix))
   }
+
+  async function exportOlderVersion(versionNumber: number, ext: "md" | "pdf") {
+    if (!sessionId) return
+    setLoadingVersion(versionNumber)
+    try {
+      const res = await fetch(
+        `/api/chat-session/${encodeURIComponent(sessionId)}/guide-versions/${versionNumber}`,
+        { cache: "no-store" },
+      )
+      if (!res.ok) return
+      const body = await res.json() as { content_text?: string }
+      if (!body.content_text) return
+      const suffix = `v${versionNumber}`
+      if (ext === "md") {
+        downloadMarkdown(body.content_text, buildFilename(assignmentTitle, courseName, "md", suffix))
+      } else {
+        await printMarkdownAsPdf(body.content_text, buildFilename(assignmentTitle, courseName, "pdf", suffix))
+      }
+    } finally {
+      setLoadingVersion(null)
+      setOpen(false)
+    }
+  }
+
+  const latestLabel = latestVersion
+    ? `Export Latest (v${latestVersion.version_number})`
+    : "Export Guide"
 
   return (
     <div className="relative">
@@ -108,21 +172,65 @@ export function GuideExportButton({ guideMarkdown, assignmentTitle, courseName }
             className="fixed inset-0 z-10"
             onClick={() => setOpen(false)}
           />
-          <div className="absolute right-0 z-20 mt-1 w-40 rounded-md border border-border bg-background shadow-md">
+          <div className="absolute right-0 z-20 mt-1 min-w-[180px] rounded-md border border-border bg-background shadow-md">
+            {/* Current / latest version */}
+            <div className="px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {latestLabel}
+            </div>
             <button
               className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted"
-              onClick={exportMarkdown}
+              onClick={exportCurrentMarkdown}
             >
               <FileText className="h-4 w-4 text-muted-foreground" />
               Export as .md
             </button>
             <button
               className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted"
-              onClick={exportPdf}
+              onClick={exportCurrentPdf}
             >
               <FileDown className="h-4 w-4 text-muted-foreground" />
               Export as .pdf
             </button>
+
+            {/* Older versions */}
+            {hasMultipleVersions && olderVersions.length > 0 && (
+              <>
+                <div className="my-1 border-t border-border/60" />
+                <div className="px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Older Versions
+                </div>
+                {olderVersions.map((v) => (
+                  <div key={v.version_number} className="px-2 pb-1">
+                    <div className="rounded-md border border-border/50 bg-muted/30 px-2 py-1.5">
+                      <p className="mb-1 text-[11px] text-muted-foreground">
+                        v{v.version_number} — {formatVersionDate(v.created_at)}
+                        {v.source === "regenerated" ? " (regenerated)" : ""}
+                      </p>
+                      <div className="flex gap-2">
+                        <button
+                          disabled={loadingVersion === v.version_number}
+                          onClick={() => exportOlderVersion(v.version_number, "md")}
+                          className="text-[12px] text-blue-500 hover:underline disabled:opacity-50"
+                        >
+                          .md
+                        </button>
+                        <span className="text-muted-foreground/50">|</span>
+                        <button
+                          disabled={loadingVersion === v.version_number}
+                          onClick={() => exportOlderVersion(v.version_number, "pdf")}
+                          className="text-[12px] text-blue-500 hover:underline disabled:opacity-50"
+                        >
+                          .pdf
+                        </button>
+                        {loadingVersion === v.version_number && (
+                          <span className="text-[11px] text-muted-foreground">loading…</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </>
+            )}
           </div>
         </>
       )}

--- a/webapp/src/lib/chat-repository.ts
+++ b/webapp/src/lib/chat-repository.ts
@@ -82,6 +82,16 @@ type DbChatMessage = {
   created_at: string;
 };
 
+type DbGuideVersion = {
+  id: string;
+  session_id: string;
+  version_number: number;
+  content_text: string;
+  source: "initial_run" | "regenerated";
+  message_index_at_creation: number;
+  created_at: string;
+};
+
 type DbChatMessageListPreview = {
   session_id: string;
   message_index: number;
@@ -904,7 +914,7 @@ async function getPersistedSessionSnapshotWithMessageLimit(
       ? Math.max(1, Math.min(40, Math.floor(messageLimit)))
       : null;
 
-  const [snapshot, messages] = await Promise.all([
+  const [snapshot, messages, latestVersion] = await Promise.all([
     selectFirst<DbAssignmentSnapshot>({
       table: "assignment_snapshots",
       query: {
@@ -923,6 +933,15 @@ async function getPersistedSessionSnapshotWithMessageLimit(
         ...(boundedMessageLimit == null ? {} : { limit: boundedMessageLimit }),
       },
     }),
+    selectFirst<DbGuideVersion>({
+      table: "guide_versions",
+      query: {
+        session_id: eq(session.id),
+        select: "id,version_number,content_text",
+        order: "version_number.desc",
+        limit: 1,
+      },
+    }),
   ]);
 
   if (!snapshot) {
@@ -930,8 +949,12 @@ async function getPersistedSessionSnapshotWithMessageLimit(
   }
 
   const allMessages = boundedMessageLimit == null ? messages : [...messages].reverse();
+  // Prefer the latest explicit guide version; fall back to first assistant message for
+  // sessions created before the guide_versions migration.
   const guideMarkdown =
-    allMessages.find((m) => m.sender_role === "assistant")?.content_text ?? "";
+    latestVersion?.content_text ||
+    allMessages.find((m) => m.sender_role === "assistant")?.content_text ||
+    "";
 
   const payload = sanitizePayloadForResponse(
     asObject(snapshot.raw_payload) as AssignmentPayload,
@@ -1711,4 +1734,106 @@ export async function getSessionGuideAndRecentHistory(
     assignmentUuid: snapshot.assignmentUuid,
     assignmentRecordId: snapshot.assignmentRecordId ?? null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Guide versioning
+// ---------------------------------------------------------------------------
+
+export async function insertGuideVersion(input: {
+  sessionId: string;
+  versionNumber: number;
+  contentText: string;
+  source: "initial_run" | "regenerated";
+  messageIndexAtCreation: number;
+}): Promise<{ id: string; version_number: number }> {
+  const row = await insertSingle<DbGuideVersion>({
+    table: "guide_versions",
+    row: {
+      session_id: input.sessionId,
+      version_number: input.versionNumber,
+      content_text: input.contentText,
+      source: input.source,
+      message_index_at_creation: input.messageIndexAtCreation,
+    },
+  });
+  return { id: row.id, version_number: row.version_number };
+}
+
+export async function getLatestGuideVersion(sessionId: string) {
+  return selectFirst<DbGuideVersion>({
+    table: "guide_versions",
+    query: {
+      session_id: eq(sessionId),
+      select: "id,version_number,content_text,source,created_at",
+      order: "version_number.desc",
+      limit: 1,
+    },
+  });
+}
+
+export async function getNextGuideVersionNumber(sessionId: string): Promise<number> {
+  const latest = await selectFirst<Pick<DbGuideVersion, "version_number">>({
+    table: "guide_versions",
+    query: {
+      session_id: eq(sessionId),
+      select: "version_number",
+      order: "version_number.desc",
+      limit: 1,
+    },
+  });
+  return (latest?.version_number ?? 0) + 1;
+}
+
+export async function listGuideVersions(sessionId: string): Promise<
+  Array<{
+    version_number: number;
+    source: string;
+    content_length: number;
+    created_at: string;
+  }>
+> {
+  const rows = await selectMany<DbGuideVersion>({
+    table: "guide_versions",
+    query: {
+      session_id: eq(sessionId),
+      select: "version_number,source,content_text,created_at",
+      order: "version_number.asc",
+    },
+  });
+  return rows.map((row) => ({
+    version_number: row.version_number,
+    source: row.source,
+    content_length: row.content_text.length,
+    created_at: row.created_at,
+  }));
+}
+
+export async function getGuideVersionContent(
+  sessionId: string,
+  versionNumber: number,
+): Promise<string | null> {
+  const row = await selectFirst<DbGuideVersion>({
+    table: "guide_versions",
+    query: {
+      session_id: eq(sessionId),
+      version_number: eq(versionNumber),
+      select: "version_number,content_text,source,created_at",
+      limit: 1,
+    },
+  });
+  return row ? row.content_text : null;
+}
+
+export async function getHighestMessageIndex(sessionId: string): Promise<number> {
+  const row = await selectFirst<Pick<DbChatMessage, "message_index">>({
+    table: "chat_messages",
+    query: {
+      session_id: eq(sessionId),
+      select: "message_index",
+      order: "message_index.desc",
+      limit: 1,
+    },
+  });
+  return row?.message_index ?? 0;
 }

--- a/webapp/src/lib/chat-session-runner.ts
+++ b/webapp/src/lib/chat-session-runner.ts
@@ -10,7 +10,9 @@ import {
   setRuntimeProgress,
 } from "@/lib/chat-runtime-store";
 import {
+  getHighestMessageIndex,
   getSessionGuideAndRecentHistory,
+  insertGuideVersion,
   listSignedSnapshotPdfFiles,
   updateChatMessageContent,
   updateChatSessionStatus,
@@ -52,7 +54,6 @@ const MAX_CHAT_OBJECT_KEYS = 40;
 const MAX_CHAT_OBJECT_DEPTH = 4;
 const FOLLOWUP_CHAT_HISTORY_LIMIT = 8;
 const ASSISTANT_PERSIST_INTERVAL_MS = 1500;
-type FollowupThinkingMode = "normal" | "thinking";
 
 function toErrorMessage(err: unknown) {
   if (err instanceof Error) return err.message;
@@ -382,6 +383,18 @@ async function runInitialGuide(input: {
         await updateChatSessionStatus(sessionId, "completed");
 
         markRuntimeCompleted(sessionId, guideMarkdown);
+
+        // Persist v1 — best-effort; don't fail the whole run if this errors
+        insertGuideVersion({
+          sessionId,
+          versionNumber: 1,
+          contentText: guideMarkdown,
+          source: "initial_run",
+          messageIndexAtCreation: 0,
+        }).catch((err: unknown) => {
+          console.error("[chat-runner] Failed to persist guide v1:", err);
+        });
+
         hasCompleted = true;
         break;
       }
@@ -439,11 +452,10 @@ async function runFollowupChat(input: {
   sessionId: string;
   assistantMessageId: string;
   userMessageContent: string;
-  thinkingMode: FollowupThinkingMode;
   requestUrl: string;
   attachments?: Array<{ filename: string; file_sha256: string; storage_path: string }>;
 }) {
-  const { sessionId, assistantMessageId, userMessageContent, thinkingMode, requestUrl, attachments } = input;
+  const { sessionId, assistantMessageId, userMessageContent, requestUrl, attachments } = input;
 
   let flushTimer: ReturnType<typeof setInterval> | null = null;
   let bufferedDelta = "";
@@ -475,7 +487,6 @@ async function runFollowupChat(input: {
     lastPersistAt = now;
     persistAssistant(assistantContent, {
       streaming: true,
-      thinking_mode: thinkingMode,
     });
   };
 
@@ -589,7 +600,7 @@ async function runFollowupChat(input: {
         chat_history: chatHistory,
         retrieval_context: retrievalContext,
         user_message: userMessageContent,
-        thinking_mode: thinkingMode === "thinking",
+        thinking_mode: false,
         calendar_context: calendarContext,
         ...(userPdfFiles.length > 0 ? { user_pdf_files: userPdfFiles } : {}),
       }),
@@ -682,7 +693,6 @@ async function runFollowupChat(input: {
           metadata: {
             streaming: false,
             completed: true,
-            thinking_mode: thinkingMode,
             ...(firstProposal ? { calendar_proposal: firstProposal } : {}),
           },
         });
@@ -741,7 +751,6 @@ async function runFollowupChat(input: {
         streaming: false,
         failed: true,
         error: errorMessage,
-        thinking_mode: thinkingMode,
       },
     }).catch(() => undefined);
 
@@ -763,12 +772,267 @@ export function startFollowupChatRun(input: {
   sessionId: string;
   assistantMessageId: string;
   userMessageContent: string;
-  thinkingMode?: FollowupThinkingMode;
   requestUrl: string;
   attachments?: Array<{ filename: string; file_sha256: string; storage_path: string }>;
 }) {
-  void runFollowupChat({
-    ...input,
-    thinkingMode: input.thinkingMode ?? "normal",
-  });
+  void runFollowupChat(input);
+}
+
+// ---------------------------------------------------------------------------
+// Guide regeneration — streams a new guide version as a chat message
+// ---------------------------------------------------------------------------
+
+const REGEN_CHAT_HISTORY_LIMIT = 50;
+const REGEN_ASSISTANT_PERSIST_INTERVAL_MS = 1500;
+
+async function runGuideRegeneration(input: {
+  sessionId: string;
+  assistantMessageId: string;
+  versionNumber: number;
+  requestUrl: string;
+}) {
+  const { sessionId, assistantMessageId, versionNumber } = input;
+  let flushTimer: ReturnType<typeof setInterval> | null = null;
+  let bufferedDelta = "";
+  let assistantContent = "";
+  let persistChain: Promise<void> = Promise.resolve();
+  let lastPersistAt = 0;
+  let pendingPersist = false;
+
+  const persistAssistant = (content: string, metadata: Record<string, unknown>) => {
+    persistChain = persistChain
+      .then(async () => {
+        await updateChatMessageContent({ messageId: assistantMessageId, content, metadata });
+      })
+      .catch(() => undefined);
+  };
+
+  const maybePersistAssistant = (force = false) => {
+    const now = Date.now();
+    if (!force && now - lastPersistAt < REGEN_ASSISTANT_PERSIST_INTERVAL_MS) {
+      pendingPersist = true;
+      return;
+    }
+    pendingPersist = false;
+    lastPersistAt = now;
+    persistAssistant(assistantContent, { streaming: true, guide_version: versionNumber });
+  };
+
+  const flushDelta = () => {
+    if (!bufferedDelta) return;
+    const delta = bufferedDelta;
+    bufferedDelta = "";
+    assistantContent += delta;
+    emitChatMessageDelta(sessionId, {
+      messageId: assistantMessageId,
+      delta,
+      content: assistantContent,
+    });
+    maybePersistAssistant();
+  };
+
+  try {
+    patchRuntimeSession(sessionId, {
+      status: "running",
+      stage: "chat_streaming",
+      progressPercent: 97,
+      statusMessage: `Updating guide (v${versionNumber})`,
+      error: undefined,
+    });
+
+    const sessionContext = await getSessionGuideAndRecentHistory(
+      sessionId,
+      REGEN_CHAT_HISTORY_LIMIT,
+    );
+    if (!sessionContext) {
+      throw new Error("Session context not found.");
+    }
+
+    const retrievalContext = retrieveLexicalContext({
+      guideMarkdown: sessionContext.guideMarkdown,
+      payload: sessionContext.payload,
+      query: "regenerate full study guide",
+      maxChunks: 6,
+      maxChars: 700,
+    });
+
+    const agentUrl = process.env.AGENT_SERVICE_URL;
+    if (!agentUrl) {
+      throw new Error("AGENT_SERVICE_URL not set");
+    }
+
+    const chatHistory = toAgentHistory(sessionContext.messages)
+      .filter((message) => message.content.trim().length > 0)
+      .slice(-REGEN_CHAT_HISTORY_LIMIT);
+    const assignmentPayload = sanitizeAssignmentPayloadForFollowup(sessionContext.payload);
+
+    const regenerationInstruction =
+      `Based on everything we have discussed so far and any files I've attached, ` +
+      `please regenerate a complete, updated study guide for this assignment. ` +
+      `Output ONLY the full guide in markdown — no conversational text, no preamble. ` +
+      `Do NOT include calendar scheduling proposals or time-block suggestions.`;
+
+    const streamResponse = await openAgentChatStream(
+      agentUrl,
+      JSON.stringify({
+        assignment_payload: assignmentPayload,
+        guide_markdown: sessionContext.guideMarkdown,
+        chat_history: chatHistory,
+        retrieval_context: retrievalContext,
+        user_message: regenerationInstruction,
+        thinking_mode: false,
+        // Omit calendar_context entirely — guide updates should not include scheduling
+      }),
+    );
+
+    if (!streamResponse.ok) {
+      const rawText = await streamResponse.text();
+      throw new Error(`Agent chat stream error (${streamResponse.status}): ${rawText}`);
+    }
+    if (!streamResponse.body) {
+      throw new Error("Agent chat stream has no body.");
+    }
+
+    flushTimer = setInterval(flushDelta, 80);
+    let hasCompleted = false;
+
+    for await (const message of readSseStream(streamResponse.body)) {
+      const parsed = parseChatEvent(message);
+      if (!parsed) continue;
+      const { event, data } = parsed;
+
+      if (event === "chat.started") {
+        patchRuntimeSession(sessionId, {
+          status: "running",
+          stage: "chat_streaming",
+          progressPercent: toPercent(data.progress_percent, 97),
+          statusMessage: `Updating guide (v${versionNumber})`,
+        });
+        continue;
+      }
+
+      if (event === "chat.delta") {
+        if (typeof data.delta === "string" && data.delta.length > 0) {
+          bufferedDelta += data.delta;
+        }
+        continue;
+      }
+
+      if (event === "chat.completed") {
+        flushDelta();
+        if (pendingPersist) maybePersistAssistant(true);
+
+        if (typeof data.assistant_message === "string" && data.assistant_message.trim()) {
+          assistantContent = data.assistant_message;
+        }
+
+        await persistChain;
+
+        // Strip any calendar_proposal tags the model may emit
+        const guideMarkdown = assistantContent
+          .replace(/<calendar_proposal>[\s\S]*?<\/calendar_proposal>/g, "")
+          .trim();
+
+        if (!guideMarkdown) {
+          throw new Error("Agent returned empty guide markdown during regeneration.");
+        }
+
+        const highestIndex = await getHighestMessageIndex(sessionId).catch(() => 0);
+
+        await insertGuideVersion({
+          sessionId,
+          versionNumber,
+          contentText: guideMarkdown,
+          source: "regenerated",
+          messageIndexAtCreation: highestIndex,
+        });
+
+        await updateChatMessageContent({
+          messageId: assistantMessageId,
+          content: guideMarkdown,
+          metadata: {
+            streaming: false,
+            completed: true,
+            guide_version: versionNumber,
+          },
+        });
+
+        emitChatMessageCompleted(sessionId, {
+          messageId: assistantMessageId,
+          content: guideMarkdown,
+        });
+
+        patchRuntimeSession(sessionId, {
+          status: "completed",
+          stage: "completed",
+          progressPercent: 100,
+          statusMessage: "Guide updated",
+          error: undefined,
+        });
+
+        hasCompleted = true;
+        break;
+      }
+
+      if (event === "chat.error") {
+        const messageText =
+          typeof data.message === "string" && data.message.trim()
+            ? data.message
+            : "Guide update failed.";
+        throw new Error(messageText);
+      }
+    }
+
+    flushDelta();
+    if (!hasCompleted) {
+      throw new Error("Agent stream ended before completion during guide update.");
+    }
+  } catch (err) {
+    flushDelta();
+    if (pendingPersist) maybePersistAssistant(true);
+    await persistChain;
+
+    const errorMessage = toErrorMessage(err);
+
+    const fallbackContent = assistantContent.trim()
+      ? `${assistantContent}\n\n_Guide update could not be completed: ${errorMessage}_`
+      : `_Guide update failed: ${errorMessage}_`;
+
+    await updateChatMessageContent({
+      messageId: assistantMessageId,
+      content: fallbackContent,
+      metadata: {
+        streaming: false,
+        failed: true,
+        error: errorMessage,
+        guide_version: versionNumber,
+      },
+    }).catch(() => undefined);
+
+    emitChatMessageCompleted(sessionId, {
+      messageId: assistantMessageId,
+      content: fallbackContent,
+    });
+
+    patchRuntimeSession(sessionId, {
+      status: "completed",
+      stage: "completed",
+      progressPercent: 100,
+      statusMessage: "Guide update failed",
+      error: errorMessage,
+    });
+  } finally {
+    if (flushTimer) {
+      clearInterval(flushTimer);
+    }
+  }
+}
+
+export function startGuideRegeneration(input: {
+  sessionId: string;
+  assistantMessageId: string;
+  versionNumber: number;
+  requestUrl: string;
+}) {
+  void runGuideRegeneration(input);
 }


### PR DESCRIPTION
This pull request introduces a new guide versioning and regeneration feature for chat sessions, while also cleaning up the chat message API by removing the deprecated "thinking mode" functionality. The main changes include new API endpoints for listing and fetching guide versions, a regeneration endpoint, and corresponding UI updates to support guide version management and regeneration from the dashboard. Additionally, the "thinking mode" toggle and related backend logic have been removed for simplification.

**Guide Versioning and Regeneration Feature:**

* Added new API endpoints:
  - `guide-versions`: Lists all guide versions for a chat session (`route.ts`). ([webapp/src/app/api/chat-session/[sessionId]/guide-versions/route.tsR1-R32](diffhunk://#diff-1de0eee6519f17959008923d69f21a4778a6a535e5e2548f4c4392f7bd038067R1-R32))
  - `guide-versions/[versionNumber]`: Fetches the content of a specific guide version (`route.ts`). ([webapp/src/app/api/chat-session/[sessionId]/guide-versions/[versionNumber]/route.tsR1-R40](diffhunk://#diff-71badefc8e90a4308f0b4beb93400dab7e002096aa1973d768875eb4071a2f49R1-R40))
  - `regenerate-guide`: Initiates guide regeneration for a completed session (`route.ts`). ([webapp/src/app/api/chat-session/[sessionId]/regenerate-guide/route.tsR1-R88](diffhunk://#diff-d025944c02d4b34fd104d90f386ac889c829e72d37569eea49b0c8ffba38f3f2R1-R88))
* Updated the dashboard UI (`page.tsx`) to:
  - Fetch and display available guide versions and allow scrolling to specific versions. [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR114-R120) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR316-R317) [[3]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR343-R350) [[4]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR667-R689) [[5]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1501-R1502) [[6]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1406) [[7]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1431-R1438)
  - Add an "Update Guide" button to trigger guide regeneration, with loading state handling. [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1137-R1158) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1583-R1595)
  - Pass guide version information to relevant components.

**Removal of "Thinking Mode":**

* Removed the "thinking mode" toggle and all related UI and backend logic:
  - Eliminated the `isThinkingModeEnabled` state and button from the dashboard. [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adL300) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adL1480-L1490)
  - Removed `thinking_mode` from the chat message POST payload and metadata. ([webapp/src/app/dashboard/chat/page.tsxL1140](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adL1140), [webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL33-L35](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L33-L35), [webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL100](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L100), [webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL112](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L112), [webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL123](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L123))
  - Deleted backend validation and handling for `thinking_mode`. ([webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL11](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L11), [webapp/src/app/api/chat-session/[sessionId]/messages/route.tsL62-L68](diffhunk://#diff-fa365f157ef3df0183d6f2953bc6690dc632b18796810c4eda4de735656f55c0L62-L68))

**UI/UX Improvements:**

* Added guide version markers in the chat thread for easier navigation and context. [[1]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1406) [[2]](diffhunk://#diff-8360df83cc9d9689084b28bf95f60879075ee4cf25aa65d1f9c6d86c968554adR1431-R1438)
* Updated icon usage to include a refresh icon for the guide regeneration button.

These changes collectively improve the chat session experience by enabling guide version management and streamlining the chat interface.

Closes #50 