### PR TITLE
[Feature] Rubric coverage + guide version diff in chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Calendar planning flow (new):
 - `POST /api/chat-session`
 - `GET /api/chat-session/:sessionId`
 - `GET /api/chat-session/:sessionId/events` (SSE)
+- `GET /api/chat-session/:sessionId/guide-versions`
+- `GET /api/chat-session/:sessionId/guide-versions/:versionNumber`
+- `GET /api/chat-session/:sessionId/guide-versions/compare?from_version=<n>&to_version=<n>`
+- `GET /api/chat-session/:sessionId/rubric-coverage?version=<n>`
 - `POST /api/run-agent` (legacy proxy path)
 - `GET /api/integrations/google-calendar`
 - `GET /api/integrations/google-calendar/connect`
@@ -282,5 +286,4 @@ python -m pytest
 - Add authentication/authorization and production-grade security constraints.
 - Stabilize and version contracts across all components.
 - Expand automated contract/integration/e2e coverage across extension, web app, and agent service.
-
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -50,6 +50,10 @@ Implemented in `src/lib/calendar-planner.ts`.
 - `POST /api/chat-session`
 - `GET /api/chat-session/:sessionId`
 - `GET /api/chat-session/:sessionId/events` (SSE)
+- `GET /api/chat-session/:sessionId/guide-versions`
+- `GET /api/chat-session/:sessionId/guide-versions/:versionNumber`
+- `GET /api/chat-session/:sessionId/guide-versions/compare?from_version=<n>&to_version=<n>`
+- `GET /api/chat-session/:sessionId/rubric-coverage?version=<n>`
 - `POST /api/run-agent` (legacy proxy)
 
 ### Google Calendar Integration

--- a/webapp/src/app/api/chat-session/[sessionId]/guide-versions/compare/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/guide-versions/compare/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import {
+  assertSessionOwnership,
+  getGuideVersionContent,
+} from "@/lib/chat-repository";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+import { buildGuideDiff } from "@/lib/guide-diff";
+
+export const runtime = "nodejs";
+
+function toPositiveVersion(raw: string | null) {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const session = await assertSessionOwnership(sessionId, userId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const fromVersion = toPositiveVersion(url.searchParams.get("from_version"));
+  const toVersion = toPositiveVersion(url.searchParams.get("to_version"));
+
+  if (!fromVersion || !toVersion || fromVersion === toVersion) {
+    return NextResponse.json(
+      { error: "Invalid from_version or to_version" },
+      { status: 400 },
+    );
+  }
+
+  const [fromText, toText] = await Promise.all([
+    getGuideVersionContent(sessionId, fromVersion),
+    getGuideVersionContent(sessionId, toVersion),
+  ]);
+
+  if (fromText == null || toText == null) {
+    return NextResponse.json(
+      { error: "Guide version not found" },
+      { status: 404 },
+    );
+  }
+
+  const result = buildGuideDiff(fromText, toText);
+  const response = NextResponse.json({
+    ok: true,
+    from_version: fromVersion,
+    to_version: toVersion,
+    summary: result.summary,
+    diff: result.diff,
+  });
+
+  if (resolvedUser?.refreshedSession) {
+    applyAuthCookies(response, resolvedUser.refreshedSession);
+  }
+  return response;
+}

--- a/webapp/src/app/api/chat-session/[sessionId]/rubric-coverage/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/rubric-coverage/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import {
+  assertSessionOwnership,
+  getGuideVersionContent,
+  getSessionGuideAndHistory,
+} from "@/lib/chat-repository";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+import { analyzeRubricCoverage } from "@/lib/rubric-coverage";
+
+export const runtime = "nodejs";
+
+function toPositiveVersion(raw: string | null) {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  const { sessionId } = await params;
+
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const session = await assertSessionOwnership(sessionId, userId);
+  if (!session) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const url = new URL(req.url);
+  const version = toPositiveVersion(url.searchParams.get("version"));
+  if (!version) {
+    return NextResponse.json({ error: "Invalid version" }, { status: 400 });
+  }
+
+  const [guideVersionContent, sessionGuideAndHistory] = await Promise.all([
+    getGuideVersionContent(sessionId, version),
+    getSessionGuideAndHistory(sessionId),
+  ]);
+
+  if (guideVersionContent == null) {
+    return NextResponse.json({ error: "Guide version not found" }, { status: 404 });
+  }
+
+  if (!sessionGuideAndHistory) {
+    return NextResponse.json({ error: "Session not found for user" }, { status: 404 });
+  }
+
+  const coverage = analyzeRubricCoverage(
+    guideVersionContent,
+    sessionGuideAndHistory.payload,
+  );
+
+  const response = NextResponse.json({
+    ok: true,
+    version_number: version,
+    rubric_available: coverage.rubric_available,
+    criteria: coverage.criteria,
+  });
+
+  if (resolvedUser?.refreshedSession) {
+    applyAuthCookies(response, resolvedUser.refreshedSession);
+  }
+  return response;
+}

--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -118,6 +118,37 @@ type GuideVersionMeta = {
   created_at: string
 }
 
+type GuideVersionDiffLine = {
+  type: "context" | "added" | "removed"
+  text: string
+}
+
+type GuideVersionCompareResponse = {
+  ok: boolean
+  from_version: number
+  to_version: number
+  summary: {
+    added_lines: number
+    removed_lines: number
+    changed_sections: number
+  }
+  diff: GuideVersionDiffLine[]
+}
+
+type RubricCoverageCriterion = {
+  index: number
+  criterion_text: string
+  status: "covered" | "partial" | "missing"
+  matched_snippets: string[]
+}
+
+type RubricCoverageResponse = {
+  ok: boolean
+  version_number: number
+  rubric_available: boolean
+  criteria: RubricCoverageCriterion[]
+}
+
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
 const THINK_OPEN_TAG = "<think>"
 const THINK_CLOSE_TAG = "</think>"
@@ -266,6 +297,17 @@ function stageLabel(stage: ChatSessionStage) {
   }
 }
 
+function rubricStatusClass(status: RubricCoverageCriterion["status"]) {
+  switch (status) {
+    case "covered":
+      return "border-emerald-300/70 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+    case "partial":
+      return "border-amber-300/70 bg-amber-500/15 text-amber-700 dark:text-amber-300"
+    default:
+      return "border-zinc-300/70 bg-zinc-500/15 text-zinc-700 dark:text-zinc-300"
+  }
+}
+
 function formatDateTime(value: number | string | null | undefined) {
   if (value == null) return null
   const date = new Date(value)
@@ -315,6 +357,17 @@ function DashboardChatPageContent() {
   const [fileError, setFileError] = useState<string | null>(null)
   const [guideVersions, setGuideVersions] = useState<GuideVersionMeta[]>([])
   const [isRegenerating, setIsRegenerating] = useState(false)
+  const [isCompareDialogOpen, setIsCompareDialogOpen] = useState(false)
+  const [compareFromVersion, setCompareFromVersion] = useState<number | null>(null)
+  const [compareToVersion, setCompareToVersion] = useState<number | null>(null)
+  const [isCompareLoading, setIsCompareLoading] = useState(false)
+  const [compareError, setCompareError] = useState<string | null>(null)
+  const [compareResult, setCompareResult] = useState<GuideVersionCompareResponse | null>(null)
+  const [isRubricDialogOpen, setIsRubricDialogOpen] = useState(false)
+  const [rubricVersion, setRubricVersion] = useState<number | null>(null)
+  const [isRubricLoading, setIsRubricLoading] = useState(false)
+  const [rubricError, setRubricError] = useState<string | null>(null)
+  const [rubricResult, setRubricResult] = useState<RubricCoverageResponse | null>(null)
   const threadContainerRef = useRef<HTMLDivElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -687,6 +740,30 @@ function DashboardChatPageContent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, session?.status])
 
+  useEffect(() => {
+    const availableVersions = new Set(guideVersions.map((entry) => entry.version_number))
+    const latest = guideVersions.length > 0 ? guideVersions[guideVersions.length - 1].version_number : null
+    const previous = guideVersions.length > 1 ? guideVersions[guideVersions.length - 2].version_number : null
+
+    setRubricVersion((current) => {
+      if (latest == null) return null
+      if (current != null && availableVersions.has(current)) return current
+      return latest
+    })
+
+    setCompareFromVersion((current) => {
+      if (previous == null) return null
+      if (current != null && availableVersions.has(current)) return current
+      return previous
+    })
+
+    setCompareToVersion((current) => {
+      if (latest == null || previous == null) return null
+      if (current != null && availableVersions.has(current)) return current
+      return latest
+    })
+  }, [guideVersions])
+
   // Restore calendar proposals from persisted message metadata on page load / session change
   useEffect(() => {
     if (!session || session.session_id !== sessionId) return
@@ -843,6 +920,8 @@ function DashboardChatPageContent() {
         effectiveSession.stage === "chat_streaming") &&
       !isSending,
   )
+  const hasVersionCompare = guideVersions.length > 1
+  const hasGuideVersions = guideVersions.length > 0
   const latestAssistantMessageId = latestAssistantMessageIdRef.current
 
   const pendingDeleteSession = pendingDeleteSessionId
@@ -1153,6 +1232,91 @@ function DashboardChatPageContent() {
     } catch {
       setErrorText("Failed to start guide regeneration.")
       setIsRegenerating(false)
+    }
+  }
+
+  async function readRouteError(response: Response, fallback: string) {
+    const body = await response.json().catch(() => ({})) as { error?: string }
+    if (typeof body.error === "string" && body.error.trim().length > 0) {
+      return body.error
+    }
+    return fallback
+  }
+
+  async function handleRunVersionCompare() {
+    if (!sessionId || compareFromVersion == null || compareToVersion == null) return
+    if (compareFromVersion === compareToVersion) {
+      setCompareError("Please select two different versions.")
+      return
+    }
+
+    setIsCompareLoading(true)
+    setCompareError(null)
+
+    try {
+      const params = new URLSearchParams({
+        from_version: String(compareFromVersion),
+        to_version: String(compareToVersion),
+      })
+      const response = await fetch(
+        `/api/chat-session/${encodeURIComponent(sessionId)}/guide-versions/compare?${params.toString()}`,
+        { cache: "no-store" },
+      )
+      if (!response.ok) {
+        setCompareResult(null)
+        setCompareError(await readRouteError(response, `Compare failed (${response.status})`))
+        return
+      }
+
+      const body = await response.json() as GuideVersionCompareResponse
+      if (!body?.ok || !Array.isArray(body.diff)) {
+        setCompareResult(null)
+        setCompareError("Unexpected compare response.")
+        return
+      }
+
+      setCompareResult(body)
+    } catch {
+      setCompareResult(null)
+      setCompareError("Failed to compare guide versions.")
+    } finally {
+      setIsCompareLoading(false)
+    }
+  }
+
+  async function handleRunRubricCoverage() {
+    if (!sessionId || rubricVersion == null) return
+
+    setIsRubricLoading(true)
+    setRubricError(null)
+
+    try {
+      const params = new URLSearchParams({
+        version: String(rubricVersion),
+      })
+      const response = await fetch(
+        `/api/chat-session/${encodeURIComponent(sessionId)}/rubric-coverage?${params.toString()}`,
+        { cache: "no-store" },
+      )
+      if (!response.ok) {
+        setRubricResult(null)
+        setRubricError(await readRouteError(response, `Coverage check failed (${response.status})`))
+        return
+      }
+
+      const body = await response.json() as RubricCoverageResponse
+      if (!body?.ok || !Array.isArray(body.criteria)) {
+        setRubricResult(null)
+        setRubricError("Unexpected rubric coverage response.")
+        return
+      }
+
+      setRubricResult(body)
+    } catch {
+      setRubricResult(null)
+      setRubricError("Failed to analyze rubric coverage.")
+    } finally {
+      setIsRubricLoading(false)
     }
   }
 
@@ -1643,9 +1807,279 @@ function DashboardChatPageContent() {
                 )}
               </div>
             ))}
+            <div className="mt-4 flex w-full flex-col gap-2 px-1">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!hasVersionCompare}
+                className="h-7 w-full px-2 text-[11px]"
+                onClick={() => {
+                  if (!hasVersionCompare) return
+                  setCompareError(null)
+                  setCompareResult(null)
+                  setIsCompareDialogOpen(true)
+                }}
+                title={hasVersionCompare ? "Compare two guide versions" : "Need at least 2 guide versions"}
+              >
+                Compare
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!hasGuideVersions}
+                className="h-7 w-full px-2 text-[11px]"
+                onClick={() => {
+                  if (!hasGuideVersions) return
+                  setRubricError(null)
+                  setRubricResult(null)
+                  setIsRubricDialogOpen(true)
+                }}
+                title="Analyze rubric coverage for a guide version"
+              >
+                Rubric
+              </Button>
+            </div>
           </div>
         )}
       </motion.div>
+
+      <Dialog
+        open={isCompareDialogOpen}
+        onOpenChange={(open) => {
+          setIsCompareDialogOpen(open)
+          if (!open) {
+            setCompareError(null)
+            setCompareResult(null)
+          }
+        }}
+      >
+        <DialogContent className="max-h-[85vh] w-[95vw] max-w-4xl overflow-hidden p-0">
+          <DialogHeader className="border-b border-border/70 px-5 py-4">
+            <DialogTitle>Guide Version Compare</DialogTitle>
+            <DialogDescription>
+              Compare two guide versions with added, removed, and unchanged lines.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="border-b border-border/60 px-5 py-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <label className="flex min-w-0 flex-1 flex-col gap-1 text-xs font-medium text-muted-foreground">
+                From Version
+                <select
+                  className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+                  value={compareFromVersion != null ? String(compareFromVersion) : ""}
+                  onChange={(event) => {
+                    setCompareFromVersion(Number.parseInt(event.target.value, 10))
+                  }}
+                >
+                  {guideVersions.map((version) => (
+                    <option key={`from-${version.version_number}`} value={version.version_number}>
+                      v{version.version_number}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex min-w-0 flex-1 flex-col gap-1 text-xs font-medium text-muted-foreground">
+                To Version
+                <select
+                  className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+                  value={compareToVersion != null ? String(compareToVersion) : ""}
+                  onChange={(event) => {
+                    setCompareToVersion(Number.parseInt(event.target.value, 10))
+                  }}
+                >
+                  {guideVersions.map((version) => (
+                    <option key={`to-${version.version_number}`} value={version.version_number}>
+                      v{version.version_number}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button
+                type="button"
+                onClick={() => void handleRunVersionCompare()}
+                disabled={
+                  isCompareLoading ||
+                  compareFromVersion == null ||
+                  compareToVersion == null ||
+                  compareFromVersion === compareToVersion
+                }
+                className="h-9 shrink-0"
+              >
+                {isCompareLoading ? (
+                  <>
+                    <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin" />
+                    Comparing...
+                  </>
+                ) : (
+                  "Run Compare"
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <div className="max-h-[calc(85vh-182px)] overflow-y-auto px-5 py-4">
+            {compareError ? (
+              <p className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {compareError}
+              </p>
+            ) : null}
+
+            {!compareResult && !compareError ? (
+              <p className="text-sm text-muted-foreground">Choose versions and run compare to see differences.</p>
+            ) : null}
+
+            {compareResult ? (
+              <div className="space-y-3">
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="outline" className="border-emerald-300/70 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300">
+                    + {compareResult.summary.added_lines} lines
+                  </Badge>
+                  <Badge variant="outline" className="border-rose-300/70 bg-rose-500/15 text-rose-700 dark:text-rose-300">
+                    - {compareResult.summary.removed_lines} lines
+                  </Badge>
+                  <Badge variant="outline">
+                    {compareResult.summary.changed_sections} sections changed
+                  </Badge>
+                </div>
+
+                <div className="overflow-hidden rounded-md border border-border/70">
+                  <div className="max-h-[52vh] overflow-y-auto">
+                    {compareResult.diff.length > 0 ? (
+                      compareResult.diff.map((line, index) => {
+                        const marker = line.type === "added" ? "+" : line.type === "removed" ? "-" : " "
+                        const rowTone =
+                          line.type === "added"
+                            ? "bg-emerald-500/10 text-emerald-900 dark:text-emerald-200"
+                            : line.type === "removed"
+                            ? "bg-rose-500/10 text-rose-900 dark:text-rose-200"
+                            : "bg-background text-muted-foreground"
+                        return (
+                          <div
+                            key={`${line.type}-${index}-${line.text.slice(0, 24)}`}
+                            className={`grid grid-cols-[1.5rem_minmax(0,1fr)] gap-1 border-b border-border/50 px-2 py-1.5 text-[12px] leading-5 ${rowTone}`}
+                          >
+                            <span className="select-none text-center [font-family:var(--font-space-mono)]">{marker}</span>
+                            <pre className="m-0 whitespace-pre-wrap break-words [font-family:var(--font-space-mono)]">
+                              {line.text || " "}
+                            </pre>
+                          </div>
+                        )
+                      })
+                    ) : (
+                      <p className="px-3 py-3 text-sm text-muted-foreground">No line differences found.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={isRubricDialogOpen}
+        onOpenChange={(open) => {
+          setIsRubricDialogOpen(open)
+          if (!open) {
+            setRubricError(null)
+            setRubricResult(null)
+          }
+        }}
+      >
+        <DialogContent className="max-h-[85vh] w-[95vw] max-w-3xl overflow-hidden p-0">
+          <DialogHeader className="border-b border-border/70 px-5 py-4">
+            <DialogTitle>Rubric Coverage</DialogTitle>
+            <DialogDescription>
+              Check which rubric criteria are covered by a selected guide version.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="border-b border-border/60 px-5 py-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <label className="flex min-w-0 flex-1 flex-col gap-1 text-xs font-medium text-muted-foreground">
+                Guide Version
+                <select
+                  className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+                  value={rubricVersion != null ? String(rubricVersion) : ""}
+                  onChange={(event) => {
+                    setRubricVersion(Number.parseInt(event.target.value, 10))
+                  }}
+                >
+                  {guideVersions.map((version) => (
+                    <option key={`rubric-${version.version_number}`} value={version.version_number}>
+                      v{version.version_number}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Button
+                type="button"
+                onClick={() => void handleRunRubricCoverage()}
+                disabled={isRubricLoading || rubricVersion == null}
+                className="h-9 shrink-0"
+              >
+                {isRubricLoading ? (
+                  <>
+                    <LoaderCircle className="mr-1.5 h-4 w-4 animate-spin" />
+                    Analyzing...
+                  </>
+                ) : (
+                  "Analyze Coverage"
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <div className="max-h-[calc(85vh-182px)] overflow-y-auto px-5 py-4">
+            {rubricError ? (
+              <p className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {rubricError}
+              </p>
+            ) : null}
+
+            {!rubricResult && !rubricError ? (
+              <p className="text-sm text-muted-foreground">Select a version and run analysis.</p>
+            ) : null}
+
+            {rubricResult && !rubricResult.rubric_available ? (
+              <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
+                No rubric criteria are available for this assignment. Guide version diff still works normally.
+              </div>
+            ) : null}
+
+            {rubricResult && rubricResult.rubric_available ? (
+              <div className="space-y-2">
+                {rubricResult.criteria.map((criterion) => (
+                  <div key={`criterion-${criterion.index}`} className="rounded-md border border-border/70 bg-background px-3 py-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <p className="text-sm font-medium leading-5">
+                        {criterion.index + 1}. {criterion.criterion_text}
+                      </p>
+                      <Badge variant="outline" className={rubricStatusClass(criterion.status)}>
+                        {criterion.status}
+                      </Badge>
+                    </div>
+                    {criterion.matched_snippets.length > 0 ? (
+                      <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+                        {criterion.matched_snippets.map((snippet, snippetIndex) => (
+                          <li key={`snippet-${criterion.index}-${snippetIndex}`} className="break-words">
+                            {snippet}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-2 text-xs text-muted-foreground">No matching snippets found for this criterion.</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={isContextDialogOpen} onOpenChange={setIsContextDialogOpen}>
           <DialogContent className="max-h-[85vh] w-full max-w-2xl overflow-hidden p-0">

--- a/webapp/src/lib/guide-diff.ts
+++ b/webapp/src/lib/guide-diff.ts
@@ -1,0 +1,194 @@
+export type GuideDiffLineType = "context" | "added" | "removed";
+
+export type GuideDiffLine = {
+  type: GuideDiffLineType;
+  text: string;
+};
+
+export type GuideDiffSummary = {
+  added_lines: number;
+  removed_lines: number;
+  changed_sections: number;
+};
+
+export type GuideDiffResult = {
+  summary: GuideDiffSummary;
+  diff: GuideDiffLine[];
+};
+
+const HEADING_PATTERN = /^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/;
+const MAX_LCS_MATRIX_CELLS = 4_000_000;
+
+function splitLines(value: string) {
+  return value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+}
+
+function toHeadingKey(line: string) {
+  const match = line.match(HEADING_PATTERN);
+  if (!match) return null;
+  const heading = match[1]?.trim();
+  return heading && heading.length > 0 ? heading.toLocaleLowerCase() : null;
+}
+
+function findSectionKey(lines: string[], lineIndex: number) {
+  for (let cursor = lineIndex; cursor >= 0; cursor -= 1) {
+    const key = toHeadingKey(lines[cursor] ?? "");
+    if (key) return key;
+  }
+  return "__root__";
+}
+
+function buildFallbackDiff(fromLines: string[], toLines: string[]) {
+  let prefix = 0;
+  const maxPrefix = Math.min(fromLines.length, toLines.length);
+  while (prefix < maxPrefix && fromLines[prefix] === toLines[prefix]) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  const fromRemaining = fromLines.length - prefix;
+  const toRemaining = toLines.length - prefix;
+  const maxSuffix = Math.min(fromRemaining, toRemaining);
+  while (
+    suffix < maxSuffix &&
+    fromLines[fromLines.length - 1 - suffix] === toLines[toLines.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+
+  const diff: GuideDiffLine[] = [];
+  const changedFromIndices = new Set<number>();
+  const changedToIndices = new Set<number>();
+
+  for (let i = 0; i < prefix; i += 1) {
+    diff.push({ type: "context", text: fromLines[i] ?? "" });
+  }
+
+  const fromMiddleEnd = fromLines.length - suffix;
+  for (let i = prefix; i < fromMiddleEnd; i += 1) {
+    diff.push({ type: "removed", text: fromLines[i] ?? "" });
+    changedFromIndices.add(i);
+  }
+
+  const toMiddleEnd = toLines.length - suffix;
+  for (let i = prefix; i < toMiddleEnd; i += 1) {
+    diff.push({ type: "added", text: toLines[i] ?? "" });
+    changedToIndices.add(i);
+  }
+
+  for (let i = suffix; i > 0; i -= 1) {
+    diff.push({ type: "context", text: fromLines[fromLines.length - i] ?? "" });
+  }
+
+  return { diff, changedFromIndices, changedToIndices };
+}
+
+function buildLcsDiff(fromLines: string[], toLines: string[]) {
+  const aLen = fromLines.length;
+  const bLen = toLines.length;
+  const rowWidth = bLen + 1;
+  const matrix = new Uint32Array((aLen + 1) * (bLen + 1));
+
+  for (let i = aLen - 1; i >= 0; i -= 1) {
+    for (let j = bLen - 1; j >= 0; j -= 1) {
+      const idx = i * rowWidth + j;
+      const down = matrix[(i + 1) * rowWidth + j];
+      const right = matrix[i * rowWidth + (j + 1)];
+      const diagonal = matrix[(i + 1) * rowWidth + (j + 1)];
+      matrix[idx] = fromLines[i] === toLines[j] ? diagonal + 1 : Math.max(down, right);
+    }
+  }
+
+  const diff: GuideDiffLine[] = [];
+  const changedFromIndices = new Set<number>();
+  const changedToIndices = new Set<number>();
+  let i = 0;
+  let j = 0;
+
+  while (i < aLen && j < bLen) {
+    if (fromLines[i] === toLines[j]) {
+      diff.push({ type: "context", text: fromLines[i] ?? "" });
+      i += 1;
+      j += 1;
+      continue;
+    }
+
+    const down = matrix[(i + 1) * rowWidth + j];
+    const right = matrix[i * rowWidth + (j + 1)];
+
+    if (right >= down) {
+      diff.push({ type: "added", text: toLines[j] ?? "" });
+      changedToIndices.add(j);
+      j += 1;
+    } else {
+      diff.push({ type: "removed", text: fromLines[i] ?? "" });
+      changedFromIndices.add(i);
+      i += 1;
+    }
+  }
+
+  while (i < aLen) {
+    diff.push({ type: "removed", text: fromLines[i] ?? "" });
+    changedFromIndices.add(i);
+    i += 1;
+  }
+
+  while (j < bLen) {
+    diff.push({ type: "added", text: toLines[j] ?? "" });
+    changedToIndices.add(j);
+    j += 1;
+  }
+
+  return { diff, changedFromIndices, changedToIndices };
+}
+
+function countChangedSections(
+  fromLines: string[],
+  toLines: string[],
+  changedFromIndices: Set<number>,
+  changedToIndices: Set<number>,
+) {
+  if (changedFromIndices.size === 0 && changedToIndices.size === 0) return 0;
+
+  const sectionKeys = new Set<string>();
+  for (const index of changedFromIndices) {
+    sectionKeys.add(findSectionKey(fromLines, index));
+  }
+  for (const index of changedToIndices) {
+    sectionKeys.add(findSectionKey(toLines, index));
+  }
+
+  return sectionKeys.size;
+}
+
+export function buildGuideDiff(fromText: string, toText: string): GuideDiffResult {
+  const fromLines = splitLines(fromText || "");
+  const toLines = splitLines(toText || "");
+  const lcsCells = fromLines.length * toLines.length;
+
+  const { diff, changedFromIndices, changedToIndices } =
+    lcsCells <= MAX_LCS_MATRIX_CELLS
+      ? buildLcsDiff(fromLines, toLines)
+      : buildFallbackDiff(fromLines, toLines);
+
+  let addedLines = 0;
+  let removedLines = 0;
+  for (const line of diff) {
+    if (line.type === "added") addedLines += 1;
+    if (line.type === "removed") removedLines += 1;
+  }
+
+  return {
+    summary: {
+      added_lines: addedLines,
+      removed_lines: removedLines,
+      changed_sections: countChangedSections(
+        fromLines,
+        toLines,
+        changedFromIndices,
+        changedToIndices,
+      ),
+    },
+    diff,
+  };
+}

--- a/webapp/src/lib/rubric-coverage.ts
+++ b/webapp/src/lib/rubric-coverage.ts
@@ -1,0 +1,205 @@
+import { type AssignmentPayload } from "@/lib/chat-types";
+
+export type RubricCoverageStatus = "covered" | "partial" | "missing";
+
+export type RubricCoverageCriterion = {
+  index: number;
+  criterion_text: string;
+  status: RubricCoverageStatus;
+  matched_snippets: string[];
+};
+
+export type RubricCoverageResult = {
+  rubric_available: boolean;
+  criteria: RubricCoverageCriterion[];
+};
+
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "by",
+  "for",
+  "from",
+  "has",
+  "in",
+  "is",
+  "it",
+  "of",
+  "on",
+  "or",
+  "that",
+  "the",
+  "this",
+  "to",
+  "with",
+  "your",
+  "you",
+  "their",
+  "they",
+  "them",
+  "its",
+]);
+
+function normalizeForMatch(value: string) {
+  return value
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractKeywords(value: string) {
+  const normalized = normalizeForMatch(value);
+  if (!normalized) return [];
+  const tokens = normalized.split(" ");
+  const seen = new Set<string>();
+  const keywords: string[] = [];
+  for (const token of tokens) {
+    if (token.length < 3) continue;
+    if (STOPWORDS.has(token)) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    keywords.push(token);
+  }
+  return keywords;
+}
+
+function criterionTextFromUnknown(index: number, raw: unknown) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return `Criterion ${index + 1}`;
+  }
+
+  const entry = raw as Record<string, unknown>;
+  const description =
+    typeof entry.description === "string" ? entry.description.trim() : "";
+  const longDescription =
+    typeof entry.longDescription === "string" ? entry.longDescription.trim() : "";
+
+  if (description && longDescription) {
+    return `${description}. ${longDescription}`;
+  }
+  if (description) return description;
+  if (longDescription) return longDescription;
+
+  return `Criterion ${index + 1}`;
+}
+
+function trimSnippet(value: string, maxChars = 220) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, maxChars - 3)}...`;
+}
+
+function findMatchedSnippets(
+  guideLines: string[],
+  criterionNormalized: string,
+  matchedKeywords: string[],
+) {
+  const scored: Array<{ index: number; score: number; line: string }> = [];
+
+  for (let index = 0; index < guideLines.length; index += 1) {
+    const rawLine = guideLines[index] ?? "";
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+
+    const normalizedLine = normalizeForMatch(trimmed);
+    if (!normalizedLine) continue;
+
+    let score = 0;
+    if (criterionNormalized && normalizedLine.includes(criterionNormalized)) {
+      score += 10;
+    }
+
+    const lineTokens = new Set(normalizedLine.split(" "));
+    for (const keyword of matchedKeywords) {
+      if (lineTokens.has(keyword)) {
+        score += 1;
+      }
+    }
+
+    if (score > 0) {
+      scored.push({ index, score, line: trimmed });
+    }
+  }
+
+  scored.sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    return left.index - right.index;
+  });
+
+  const snippets: string[] = [];
+  const seen = new Set<string>();
+  for (const row of scored) {
+    const snippet = trimSnippet(row.line);
+    if (!snippet || seen.has(snippet)) continue;
+    seen.add(snippet);
+    snippets.push(snippet);
+    if (snippets.length >= 2) break;
+  }
+
+  return snippets;
+}
+
+function toRubricCriteria(payload: AssignmentPayload) {
+  const rawRubric = payload.rubric;
+  if (!rawRubric || typeof rawRubric !== "object" || Array.isArray(rawRubric)) {
+    return [];
+  }
+
+  const criteria = (rawRubric as { criteria?: unknown[] }).criteria;
+  return Array.isArray(criteria) ? criteria : [];
+}
+
+export function analyzeRubricCoverage(
+  guideMarkdown: string,
+  payload: AssignmentPayload,
+): RubricCoverageResult {
+  const criteriaList = toRubricCriteria(payload);
+  if (criteriaList.length === 0) {
+    return {
+      rubric_available: false,
+      criteria: [],
+    };
+  }
+
+  const guideNormalized = normalizeForMatch(guideMarkdown || "");
+  const guideTokenSet = new Set(guideNormalized.split(" ").filter((token) => token.length > 0));
+  const guideLines = (guideMarkdown || "").split(/\r?\n/);
+
+  const criteria = criteriaList.map((criterion, index) => {
+    const criterionText = criterionTextFromUnknown(index, criterion);
+    const criterionNormalized = normalizeForMatch(criterionText);
+    const keywords = extractKeywords(criterionText);
+    const matchedKeywords = keywords.filter((keyword) => guideTokenSet.has(keyword));
+
+    let status: RubricCoverageStatus = "missing";
+    if (criterionNormalized && guideNormalized.includes(criterionNormalized)) {
+      status = "covered";
+    } else if (matchedKeywords.length >= 2) {
+      status = "partial";
+    }
+
+    const snippets = findMatchedSnippets(
+      guideLines,
+      criterionNormalized,
+      matchedKeywords,
+    );
+
+    return {
+      index,
+      criterion_text: criterionText,
+      status,
+      matched_snippets: snippets,
+    };
+  });
+
+  return {
+    rubric_available: true,
+    criteria,
+  };
+}


### PR DESCRIPTION
## Summary
- add guide version compare API with deterministic diff + summary counts
- add rubric coverage API with no-rubric safe response
- add compare/rubric dialogs in dashboard chat near the version timeline
- update webapp and repo README API endpoint lists

## Validation
- targeted eslint on changed feature files (no new errors)
- production build passed

## Linked Issues
Closes #52
Closes #53
Closes #54
Refs #55