### PR TITLE
Implement resource listing API with authentication and pagination

### DIFF
--- a/webapp/src/app/api/resources/route.ts
+++ b/webapp/src/app/api/resources/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { applyAuthCookies, resolveRequestUser } from "@/lib/auth/session";
+import { listResourcesForUser } from "@/lib/chat-repository";
+
+export const runtime = "nodejs";
+
+const DEFAULT_LIMIT = 250;
+
+function parseLimit(req: Request) {
+  const url = new URL(req.url);
+  const raw = Number(url.searchParams.get("limit") ?? DEFAULT_LIMIT);
+  if (!Number.isFinite(raw)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(500, Math.floor(raw)));
+}
+
+export async function GET(req: Request) {
+  const resolvedUser = await resolveRequestUser(req);
+  const userId = resolvedUser?.user.id ?? "";
+  if (!userId) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const limit = parseLimit(req);
+
+  try {
+    const resources = await listResourcesForUser({ userId, limit });
+
+    const response = NextResponse.json({
+      ok: true,
+      generated_at: Date.now(),
+      recent: resources.recent,
+      items: resources.items,
+      facets: resources.facets,
+    });
+    if (resolvedUser?.refreshedSession) {
+      applyAuthCookies(response, resolvedUser.refreshedSession);
+    }
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      { error: "Failed to load resources", detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/webapp/src/app/dashboard/resources/page.tsx
+++ b/webapp/src/app/dashboard/resources/page.tsx
@@ -1,61 +1,431 @@
 "use client"
 
-import { BookOpen, FileText, Download, ExternalLink } from "lucide-react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { useEffect, useMemo, useState } from "react"
+import { formatDistanceToNow } from "date-fns"
+import {
+  AlertCircle,
+  BookOpen,
+  Download,
+  ExternalLink,
+  FileText,
+  LoaderCircle,
+  MessageSquare,
+  Search,
+} from "lucide-react"
 
-const resources = [
-  { title: "AI Ethics Guide", type: "PDF", size: "1.2 MB" },
-  { title: "Linear Algebra Summary", type: "Markdown", size: "45 KB" },
-  { title: "Web Systems Best Practices", type: "PDF", size: "3.4 MB" },
-]
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+type ResourceType = "guide" | "pdf" | "link"
+type ResourceFilterType = "all" | ResourceType
+type SortMode = "newest" | "oldest" | "az"
+
+type ResourceItem = {
+  id: string
+  type: ResourceType
+  title: string
+  assignment_id: string | null
+  assignment_title: string
+  course_name: string | null
+  due_at_iso: string | null
+  session_id: string | null
+  created_at: number
+  updated_at: number
+  byte_size: number | null
+  url: string | null
+  guide_version_count: number | null
+}
+
+type ResourcesResponse = {
+  ok: true
+  generated_at: number
+  recent: ResourceItem[]
+  items: ResourceItem[]
+  facets: {
+    type_counts: {
+      all: number
+      guide: number
+      pdf: number
+      link: number
+    }
+    courses: string[]
+  }
+}
+
+function resourceTypeLabel(type: ResourceType) {
+  if (type === "guide") return "Guide"
+  if (type === "pdf") return "PDF"
+  return "Link"
+}
+
+function formatBytes(bytes: number | null) {
+  if (bytes == null) return null
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatUpdatedAt(epoch: number) {
+  if (!Number.isFinite(epoch)) return "Unknown"
+  const date = new Date(epoch)
+  if (Number.isNaN(date.getTime())) return "Unknown"
+  return formatDistanceToNow(date, { addSuffix: true })
+}
+
+function formatDueDateLabel(value: string | null) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString()
+}
 
 export default function ResourcesPage() {
+  const [data, setData] = useState<ResourcesResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorText, setErrorText] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [recentActiveType, setRecentActiveType] = useState<ResourceFilterType>("all")
+  const [activeType, setActiveType] = useState<ResourceFilterType>("all")
+  const [selectedCourse, setSelectedCourse] = useState("all")
+  const [sortMode, setSortMode] = useState<SortMode>("newest")
+
+  useEffect(() => {
+    let isDisposed = false
+
+    const loadResources = async () => {
+      setIsLoading(true)
+      try {
+        const response = await fetch("/api/resources?limit=300", {
+          method: "GET",
+          cache: "no-store",
+        })
+        if (!response.ok) {
+          const bodyText = await response.text()
+          throw new Error(bodyText || `Failed to load resources (${response.status})`)
+        }
+        const body = (await response.json()) as ResourcesResponse
+        if (isDisposed) return
+        setData(body)
+        setErrorText(null)
+      } catch (error) {
+        if (isDisposed) return
+        const message = error instanceof Error ? error.message : String(error)
+        setData(null)
+        setErrorText(message)
+      } finally {
+        if (!isDisposed) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void loadResources()
+    return () => {
+      isDisposed = true
+    }
+  }, [])
+
+  const filteredLibraryItems = useMemo(() => {
+    const resources = data?.items ?? []
+    const q = searchQuery.trim().toLowerCase()
+    const filtered = resources.filter((item) => {
+      if (activeType !== "all" && item.type !== activeType) return false
+      if (selectedCourse !== "all" && (item.course_name ?? "Unknown course") !== selectedCourse) {
+        return false
+      }
+      if (!q) return true
+      const searchable = `${item.title} ${item.assignment_title} ${item.course_name ?? ""}`.toLowerCase()
+      return searchable.includes(q)
+    })
+
+    const sorted = filtered.slice()
+    sorted.sort((left, right) => {
+      if (sortMode === "newest") {
+        return right.updated_at - left.updated_at
+      }
+      if (sortMode === "oldest") {
+        return left.updated_at - right.updated_at
+      }
+      return left.title.localeCompare(right.title)
+    })
+
+    return sorted
+  }, [activeType, data?.items, searchQuery, selectedCourse, sortMode])
+
+  const filteredRecentItems = useMemo(() => {
+    const resources = data?.recent ?? []
+    if (recentActiveType === "all") return resources
+    return resources.filter((item) => item.type === recentActiveType)
+  }, [data?.recent, recentActiveType])
+
+  const recentTypeCounts = useMemo(() => {
+    const recent = data?.recent ?? []
+    let guide = 0
+    let pdf = 0
+    let link = 0
+    for (const item of recent) {
+      if (item.type === "guide") guide += 1
+      if (item.type === "pdf") pdf += 1
+      if (item.type === "link") link += 1
+    }
+    return {
+      all: recent.length,
+      guide,
+      pdf,
+      link,
+    }
+  }, [data?.recent])
+
+  const courseOptions = useMemo(() => {
+    return data?.facets.courses ?? []
+  }, [data?.facets.courses])
+
+  function renderPrimaryAction(item: ResourceItem) {
+    if (item.type === "guide" && item.session_id) {
+      return (
+        <Button asChild size="sm" variant="outline">
+          <Link href={`/dashboard/chat?session=${encodeURIComponent(item.session_id)}`}>
+            <MessageSquare className="mr-1.5 h-3.5 w-3.5" />
+            Open Chat
+          </Link>
+        </Button>
+      )
+    }
+    if (item.type === "pdf" && item.url) {
+      return (
+        <Button asChild size="sm" variant="outline">
+          <a href={item.url} target="_blank" rel="noopener noreferrer">
+            <Download className="mr-1.5 h-3.5 w-3.5" />
+            Download
+          </a>
+        </Button>
+      )
+    }
+    if (item.type === "link" && item.url) {
+      return (
+        <Button asChild size="sm" variant="outline">
+          <a href={item.url} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+            Open Link
+          </a>
+        </Button>
+      )
+    }
+    return (
+      <Button size="sm" variant="outline" disabled>
+        Unavailable
+      </Button>
+    )
+  }
+
+  function renderTypeIcon(type: ResourceType) {
+    if (type === "guide") return <BookOpen className="h-3.5 w-3.5" />
+    if (type === "pdf") return <FileText className="h-3.5 w-3.5" />
+    return <ExternalLink className="h-3.5 w-3.5" />
+  }
+
   return (
     <div className="space-y-8">
       <div>
         <h1 className="text-3xl font-heading font-bold tracking-tight">Resources</h1>
-        <p className="text-muted-foreground">Generated study materials and external links.</p>
+        <p className="text-muted-foreground">
+          Cross-assignment library for guides, source PDFs, and assignment links.
+        </p>
       </div>
 
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {resources.map((res, i) => (
-          <Card key={i}>
-            <CardHeader className="flex flex-row items-start justify-between space-y-0">
-               <div className="space-y-1">
-                  <CardTitle>{res.title}</CardTitle>
-                  <CardDescription>{res.type} • {res.size}</CardDescription>
-               </div>
-               <div className="p-2 bg-brand-blue/10 rounded-lg text-brand-blue">
-                  <BookOpen className="h-4 w-4" />
-               </div>
-            </CardHeader>
-            <CardContent>
-               <div className="flex gap-2">
-                  <Button variant="outline" size="sm" className="flex-1">
-                     <Download className="mr-2 h-4 w-4" />
-                     Download
-                  </Button>
-                  <Button variant="ghost" size="sm">
-                     <ExternalLink className="h-4 w-4" />
-                  </Button>
-               </div>
+      {errorText ? (
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{errorText}</span>
+        </div>
+      ) : null}
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-xl font-sans font-bold">Recently Added</h2>
+          {isLoading ? (
+            <LoaderCircle className="h-4 w-4 animate-spin text-muted-foreground" />
+          ) : null}
+        </div>
+        <Tabs
+          value={recentActiveType}
+          onValueChange={(value) => setRecentActiveType(value as ResourceFilterType)}
+        >
+          <TabsList>
+            <TabsTrigger value="all">All ({recentTypeCounts.all})</TabsTrigger>
+            <TabsTrigger value="guide">Guides ({recentTypeCounts.guide})</TabsTrigger>
+            <TabsTrigger value="pdf">PDFs ({recentTypeCounts.pdf})</TabsTrigger>
+            <TabsTrigger value="link">Links ({recentTypeCounts.link})</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {isLoading ? (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={`recent-skeleton-${index}`} className="h-28 animate-pulse bg-muted/30" />
+            ))}
+          </div>
+        ) : filteredRecentItems.length === 0 ? (
+          <Card>
+            <CardContent className="py-6 text-sm text-muted-foreground">
+              No recent resources match this filter.
             </CardContent>
           </Card>
-        ))}
-      </div>
-
-      <div className="space-y-4">
-         <h2 className="text-xl font-sans font-bold">External Links</h2>
-         <div className="grid gap-2">
-            {["University Library", "Canvas LMS", "Headstart Documentation"].map(link => (
-               <a key={link} href="#" className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors">
-                  <span className="font-medium">{link}</span>
-                  <ExternalLink className="h-4 w-4 text-muted-foreground" />
-               </a>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {filteredRecentItems.map((item) => (
+              <Card key={`recent-${item.id}`} className="h-full">
+                <CardHeader className="space-y-2 pb-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <Badge variant="outline" className="inline-flex items-center gap-1">
+                      {renderTypeIcon(item.type)}
+                      {resourceTypeLabel(item.type)}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">{formatUpdatedAt(item.updated_at)}</span>
+                  </div>
+                  <CardTitle className="line-clamp-2 text-sm">{item.title}</CardTitle>
+                  <CardDescription className="line-clamp-2 text-xs">
+                    {item.assignment_title}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="pt-1">
+                  {renderPrimaryAction(item)}
+                </CardContent>
+              </Card>
             ))}
-         </div>
-      </div>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-sans font-bold">Library</h2>
+          <p className="text-sm text-muted-foreground">
+            Search across all resource types and jump directly to chat, downloads, or assignment detail.
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="space-y-4 p-4">
+            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto]">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  type="search"
+                  placeholder="Search by resource, assignment, or course..."
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  className="pl-8"
+                />
+              </div>
+
+              <Select value={selectedCourse} onValueChange={setSelectedCourse}>
+                <SelectTrigger className="w-full min-w-[170px]">
+                  <SelectValue placeholder="All courses" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All courses</SelectItem>
+                  {courseOptions.map((course) => (
+                    <SelectItem key={course} value={course}>
+                      {course}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={sortMode} onValueChange={(value) => setSortMode(value as SortMode)}>
+                <SelectTrigger className="w-full min-w-[150px]">
+                  <SelectValue placeholder="Sort" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="newest">Newest</SelectItem>
+                  <SelectItem value="oldest">Oldest</SelectItem>
+                  <SelectItem value="az">Title A-Z</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <Tabs value={activeType} onValueChange={(value) => setActiveType(value as ResourceFilterType)}>
+              <TabsList>
+                <TabsTrigger value="all">All ({data?.facets.type_counts.all ?? 0})</TabsTrigger>
+                <TabsTrigger value="guide">Guides ({data?.facets.type_counts.guide ?? 0})</TabsTrigger>
+                <TabsTrigger value="pdf">PDFs ({data?.facets.type_counts.pdf ?? 0})</TabsTrigger>
+                <TabsTrigger value="link">Links ({data?.facets.type_counts.link ?? 0})</TabsTrigger>
+              </TabsList>
+            </Tabs>
+
+            {isLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <div key={`library-skeleton-${index}`} className="h-20 animate-pulse rounded-md bg-muted/30" />
+                ))}
+              </div>
+            ) : filteredLibraryItems.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border/70 px-4 py-8 text-center text-sm text-muted-foreground">
+                No resources match your current filters.
+              </div>
+            ) : (
+              <div className="divide-y rounded-lg border">
+                {filteredLibraryItems.map((item) => {
+                  const assignmentHref = item.assignment_id
+                    ? `/dashboard/assignments/${encodeURIComponent(item.assignment_id)}`
+                    : null
+                  const dueDateLabel = formatDueDateLabel(item.due_at_iso)
+
+                  return (
+                    <div
+                      key={`library-${item.id}`}
+                      className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                      <div className="min-w-0 space-y-1.5">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Badge variant="outline" className="inline-flex items-center gap-1">
+                            {renderTypeIcon(item.type)}
+                            {resourceTypeLabel(item.type)}
+                          </Badge>
+                          {item.guide_version_count != null ? (
+                            <Badge variant="outline">v{item.guide_version_count}</Badge>
+                          ) : null}
+                          {item.byte_size != null ? (
+                            <Badge variant="outline">{formatBytes(item.byte_size)}</Badge>
+                          ) : null}
+                        </div>
+
+                        <p className="line-clamp-2 text-sm font-medium">{item.title}</p>
+                        <p className="line-clamp-1 text-xs text-muted-foreground">
+                          {item.assignment_title}
+                          {item.course_name ? ` • ${item.course_name}` : ""}
+                          {dueDateLabel ? ` • due ${dueDateLabel}` : ""}
+                          {` • ${formatUpdatedAt(item.updated_at)}`}
+                        </p>
+                      </div>
+
+                      <div className="flex shrink-0 items-center gap-2">
+                        {renderPrimaryAction(item)}
+                        {assignmentHref ? (
+                          <Button asChild variant="ghost" size="sm">
+                            <Link href={assignmentHref}>View Assignment</Link>
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
     </div>
-  );
+  )
 }

--- a/webapp/src/lib/chat-repository.ts
+++ b/webapp/src/lib/chat-repository.ts
@@ -1948,6 +1948,68 @@ export type AssignmentDetailResult = {
   latestSessionId: string | null;
 };
 
+export type ResourceItemType = "guide" | "pdf" | "link";
+
+export type ResourceLibraryItem = {
+  id: string;
+  type: ResourceItemType;
+  title: string;
+  assignment_id: string | null;
+  assignment_title: string;
+  course_name: string | null;
+  due_at_iso: string | null;
+  session_id: string | null;
+  created_at: number;
+  updated_at: number;
+  byte_size: number | null;
+  url: string | null;
+  guide_version_count: number | null;
+};
+
+export type ResourceLibraryResult = {
+  recent: ResourceLibraryItem[];
+  items: ResourceLibraryItem[];
+  facets: {
+    type_counts: {
+      all: number;
+      guide: number;
+      pdf: number;
+      link: number;
+    };
+    courses: string[];
+  };
+};
+
+type ResourceAssignmentGroup = {
+  assignmentKey: string;
+  assignmentId: string | null;
+  assignmentTitle: string;
+  courseName: string | null;
+  dueAtISO: string | null;
+  assignmentUrl: string | null;
+  latestSessionId: string;
+  latestSessionStatus: ChatSessionStatus;
+  latestSessionUpdatedAt: number;
+  latestAssignmentUuid: string;
+  attachmentCount: number;
+};
+
+function normalizeResourceAssignmentKey(item: UserChatSessionListItem) {
+  if (item.context.assignmentRecordId) {
+    return item.context.assignmentRecordId;
+  }
+  const title = item.context.assignmentTitle.trim().toLowerCase();
+  const course = (item.context.courseName ?? "").trim().toLowerCase();
+  const due = item.context.dueAtISO ?? "";
+  return `${title}::${course}::${due}`;
+}
+
+function toEpochOrFallback(value: string | null | undefined, fallback: number) {
+  if (!value) return fallback;
+  const ts = Date.parse(value);
+  return Number.isNaN(ts) ? fallback : ts;
+}
+
 export async function getAssignmentDetailForUser(input: {
   userId: string;
   assignmentId: string;
@@ -2042,5 +2104,160 @@ export async function getAssignmentDetailForUser(input: {
     latestAssignmentUuid,
     sessions,
     latestSessionId: latestSession?.id ?? null,
+  };
+}
+
+export async function listResourcesForUser(input: {
+  userId: string;
+  limit?: number;
+}): Promise<ResourceLibraryResult> {
+  const boundedLimit = Math.max(1, Math.min(500, Math.floor(input.limit ?? 250)));
+  const sessions = await listPersistedChatSessionsForUser(input.userId, 200);
+
+  if (sessions.length === 0) {
+    return {
+      recent: [],
+      items: [],
+      facets: {
+        type_counts: {
+          all: 0,
+          guide: 0,
+          pdf: 0,
+          link: 0,
+        },
+        courses: [],
+      },
+    };
+  }
+
+  const assignmentGroups = new Map<string, ResourceAssignmentGroup>();
+  for (const session of sessions) {
+    const key = normalizeResourceAssignmentKey(session);
+    if (assignmentGroups.has(key)) continue;
+    assignmentGroups.set(key, {
+      assignmentKey: key,
+      assignmentId: session.context.assignmentRecordId,
+      assignmentTitle: session.context.assignmentTitle,
+      courseName: session.context.courseName,
+      dueAtISO: session.context.dueAtISO,
+      assignmentUrl: session.context.assignmentUrl,
+      latestSessionId: session.sessionId,
+      latestSessionStatus: session.status,
+      latestSessionUpdatedAt: session.updatedAt,
+      latestAssignmentUuid: session.assignmentUuid,
+      attachmentCount: session.context.attachmentCount,
+    });
+  }
+
+  const groupedItems = await Promise.all(
+    Array.from(assignmentGroups.values()).map(async (group) => {
+      const items: ResourceLibraryItem[] = [];
+
+      if (group.assignmentUrl) {
+        items.push({
+          id: `link:${group.assignmentKey}`,
+          type: "link",
+          title: group.assignmentTitle,
+          assignment_id: group.assignmentId,
+          assignment_title: group.assignmentTitle,
+          course_name: group.courseName,
+          due_at_iso: group.dueAtISO,
+          session_id: group.latestSessionId,
+          created_at: group.latestSessionUpdatedAt,
+          updated_at: group.latestSessionUpdatedAt,
+          byte_size: null,
+          url: group.assignmentUrl,
+          guide_version_count: null,
+        });
+      }
+
+      if (
+        group.latestSessionStatus === "completed" ||
+        group.latestSessionStatus === "archived"
+      ) {
+        const versions = await listGuideVersions(group.latestSessionId).catch(() => []);
+        if (versions.length > 0) {
+          const latestVersion = versions[versions.length - 1]!;
+          const latestGuideEpoch = toEpochOrFallback(
+            latestVersion.created_at,
+            group.latestSessionUpdatedAt,
+          );
+          items.push({
+            id: `guide:${group.assignmentKey}:${group.latestSessionId}`,
+            type: "guide",
+            title: `${group.assignmentTitle} Study Guide`,
+            assignment_id: group.assignmentId,
+            assignment_title: group.assignmentTitle,
+            course_name: group.courseName,
+            due_at_iso: group.dueAtISO,
+            session_id: group.latestSessionId,
+            created_at: latestGuideEpoch,
+            updated_at: latestGuideEpoch,
+            byte_size: null,
+            url: `/dashboard/chat?session=${encodeURIComponent(group.latestSessionId)}`,
+            guide_version_count: versions.length,
+          });
+        }
+      }
+
+      if (group.attachmentCount > 0 && group.latestAssignmentUuid) {
+        const pdfFiles = await listSignedSnapshotPdfFiles(group.latestAssignmentUuid).catch(
+          () => [],
+        );
+        for (const file of pdfFiles) {
+          items.push({
+            id: `pdf:${group.assignmentKey}:${file.fileSha256}`,
+            type: "pdf",
+            title: file.filename,
+            assignment_id: group.assignmentId,
+            assignment_title: group.assignmentTitle,
+            course_name: group.courseName,
+            due_at_iso: group.dueAtISO,
+            session_id: group.latestSessionId,
+            created_at: group.latestSessionUpdatedAt,
+            updated_at: group.latestSessionUpdatedAt,
+            byte_size: file.byteSize ?? null,
+            url: file.signedUrl,
+            guide_version_count: null,
+          });
+        }
+      }
+
+      return items;
+    }),
+  );
+
+  const allItems = groupedItems
+    .flat()
+    .sort((left, right) => right.updated_at - left.updated_at || left.id.localeCompare(right.id));
+  const limitedItems = allItems.slice(0, boundedLimit);
+
+  const typeCounts = {
+    all: allItems.length,
+    guide: 0,
+    pdf: 0,
+    link: 0,
+  };
+  for (const item of allItems) {
+    if (item.type === "guide") typeCounts.guide += 1;
+    if (item.type === "pdf") typeCounts.pdf += 1;
+    if (item.type === "link") typeCounts.link += 1;
+  }
+
+  const courses = Array.from(
+    new Set(
+      allItems
+        .map((item) => toOptionalString(item.course_name))
+        .filter((name): name is string => Boolean(name)),
+    ),
+  ).sort((left, right) => left.localeCompare(right));
+
+  return {
+    recent: allItems.slice(0, 8),
+    items: limitedItems,
+    facets: {
+      type_counts: typeCounts,
+      courses,
+    },
   };
 }


### PR DESCRIPTION
This pull request introduces a new API route for listing user resources and implements the supporting logic for aggregating and returning resource library data. The main changes include the creation of the `/api/resources` endpoint, the addition of new types for resource items, and the implementation of a function to gather and organize resources (such as guides, PDFs, and links) associated with a user.

**API endpoint implementation:**

* Added a new API route handler in `route.ts` that authenticates the user, parses a `limit` parameter, calls a new resource listing function, and returns a structured JSON response with recent items, all items, and facet counts. Handles authentication and error cases.

**Resource aggregation and typing:**

* Introduced new types in `chat-repository.ts` (`ResourceItemType`, `ResourceLibraryItem`, `ResourceLibraryResult`) to represent and organize resources (guides, PDFs, links) and their metadata for the library.
* Implemented the `listResourcesForUser` function, which groups sessions by assignment, collects related resources (assignment links, study guides, PDF attachments), computes type counts and course facets, and returns a structured result for the API.