### PR TITLE
Enhance assignment categorization and improve chat display

### DIFF
--- a/.claude/plans/67.md
+++ b/.claude/plans/67.md
@@ -1,0 +1,203 @@
+# Issue #67: feat: LLM-based assignment category classification with category-specific chat system prompts
+
+**Status:** Complete (commits blocked by git permission)
+**Date:** 2026-04-25
+**Verification:** CONFIRMED
+
+## Issue Summary
+
+Issue #67 requests automatic assignment classification during initial guide generation. The agent service should classify each Canvas assignment as `coding`, `mathematics`, `science`, `speech`, `essay`, or fallback `general`, return that value as structured metadata on the final run SSE event, persist it on the webapp chat session row, and pass it back into follow-up chat requests so category-specific system prompt guidance can be appended internally. The category should not be written into assistant chat responses; it should appear only as a small UI label next to the chat session header and each chat name in the chats list.
+
+## Affected Area
+
+- Agent Service
+- Webapp
+- Database
+- Cross-system flow
+- Docs
+
+## Verification Findings
+
+The issue is real in the current codebase:
+
+- `agent_service/app/services/run_agent_service.py:291` builds the `run.completed` payload with guide, stage, progress, thinking content, and PDF extraction fields, but no `assignment_category`.
+- `agent_service/app/services/run_agent_service.py:422` calls `_stream_headstart_chat_answer()` without any category argument.
+- `agent_service/app/schemas/requests.py:95` defines `ChatStreamRequest` without `assignment_category`.
+- `agent_service/app/orchestrators/headstart_orchestrator.py:952` builds a follow-up prompt from one generic `SYSTEM_PROMPT_CHAT`; `stream_headstart_chat_answer()` at `agent_service/app/orchestrators/headstart_orchestrator.py:961` has no assignment-category parameter.
+- `webapp/src/lib/chat-session-runner.ts:367` handles `run.completed`, persists guide/PDF extraction fields, and never consumes an assignment category.
+- `webapp/src/lib/chat-session-runner.ts:668` sends follow-up chat request JSON without `assignment_category`; guide regeneration at `webapp/src/lib/chat-session-runner.ts:965` does the same.
+- `webapp/src/lib/chat-repository.ts:67` defines `DbChatSession` without `assignment_category`, and session reads at `webapp/src/lib/chat-repository.ts:1012` select no category field.
+- `webapp/src/lib/chat-types.ts:84` and `webapp/src/lib/chat-types.ts:135` lack the requested `classifying_assignment` runtime stage and persisted `assignmentCategory`.
+- `supabase/migrations/20260326_full_database_schema.sql:72` defines `public.chat_sessions` with no category column.
+- There is no existing `agent_service/app/services/classification_service.py` or unit test for classification.
+
+The architecture docs describe the run/chat orchestration and persistence flows, but they do not yet mention assignment category classification or the new `run.completed` / chat request contract.
+
+## Root Cause
+
+The current Canvas -> webapp -> agent-service flow was built around a single assignment guide contract and a single follow-up chat prompt. No assignment category is generated during `stream_run_agent_workflow()`, no database field stores it on `chat_sessions`, and no chat request schema or prompt builder consumes it later. The missing data path spans the initial run SSE completion payload, webapp persistence, follow-up request body, and orchestrator prompt construction.
+
+## Proposed Solution
+
+Add a bounded, fail-open classifier in the agent service after assignment context/PDF extraction and before guide markdown streaming begins. The classifier should use the existing NVIDIA GPT-OSS 120B client wrapper with low temperature and return a normalized category, defaulting to `general` on any error or unrecognized output. Include the category in `run.completed`, persist it to `chat_sessions.assignment_category`, load it into the persisted session snapshot, and pass it into follow-up chat and guide regeneration requests. The orchestrator should append a complete, category-specific system prompt addendum to the follow-up system prompt only when a recognized category is supplied. The category remains metadata/UI state and must not be included in the assistant response body.
+
+## Implementation Steps
+
+1. Add a Supabase migration in `supabase/migrations/`.
+   - Add nullable `assignment_category text`.
+   - Add a `CHECK` constraint allowing `NULL`, `coding`, `mathematics`, `science`, `speech`, `essay`, or `general`.
+   - Keep it backward compatible for old sessions by allowing `NULL`.
+
+2. Create `agent_service/app/services/classification_service.py`.
+   - Define allowed categories and `classify_assignment(payload, pdf_text) -> str`.
+   - Use `build_nvidia_chat_client()` from `agent_service/app/clients/llm_client.py` with `model_name="openai/gpt-oss-120b"`, low temperature, small token cap, and explicit `top_p`.
+   - Prompt for exactly one label.
+   - Normalize provider output and return `general` for exceptions, empty output, or labels outside the allowlist.
+   - Avoid logging raw assignment/PDF content.
+
+3. Update `agent_service/app/services/run_agent_service.py`.
+   - Add a lazy `_classify_assignment()` wrapper near the existing LLM wrappers.
+   - In `stream_run_agent_workflow()`, after assignment PDF/context extraction and before the guide-generation call, emit a `run.stage` with `stage: "classifying_assignment"` and status text `Classifying assignment`.
+   - Call the classifier with the sanitized run payload and extracted assignment PDF text before guide generation begins.
+   - Include `assignment_category` in the completed payload.
+   - Ensure classification failure cannot convert a successful guide generation into `run.error`.
+   - Pass `req.assignment_category or ""` through `_stream_headstart_chat_answer()` in `stream_chat_workflow()`.
+
+4. Update `agent_service/app/schemas/requests.py`.
+   - Add `assignment_category: Optional[str] = ""` to `ChatStreamRequest`.
+   - Keep the field optional so older webapp clients continue to work.
+
+5. Update `agent_service/app/orchestrators/headstart_orchestrator.py`.
+   - Add `CATEGORY_PROMPT_ADDENDA` with complete system-prompt addenda for `coding`, `mathematics`, `science`, `speech`, and `essay`, plus no-op behavior for `general`.
+   - Change `_build_followup_chat_prompt(assignment_category: str = "")` to append only the recognized addendum to `SYSTEM_PROMPT_CHAT`.
+   - Add `assignment_category: str = ""` to `stream_headstart_chat_answer()` and call the prompt builder with it.
+   - Keep the base prompt unchanged when the category is empty, `NULL`, unknown, or `general`.
+
+6. Update webapp repository types and persistence in `webapp/src/lib/chat-repository.ts`.
+   - Extend `DbChatSession` with `assignment_category?: string | null`.
+   - Add `updateChatSessionCategory(sessionId, category)`.
+   - Select `assignment_category` in session snapshot reads used by `getPersistedSessionSnapshotWithMessageLimit()` / `getSessionGuideAndRecentHistory()`.
+   - Select and return `assignment_category` in `listPersistedChatSessionsForUser()` for chats-list labels.
+   - Return `assignmentCategory` on `PersistedSessionSnapshot`.
+
+7. Update webapp shared types in `webapp/src/lib/chat-types.ts`.
+   - Add `assignmentCategory: string | null` to `PersistedSessionSnapshot`.
+   - Add `"classifying_assignment"` to `ChatSessionStage`.
+
+8. Update `webapp/src/lib/chat-session-runner.ts`.
+   - Import `updateChatSessionCategory()`.
+   - Add `"classifying_assignment"` to `toStage()`.
+   - On `run.completed`, read `data.assignment_category`; if it is a non-empty string, fire-and-forget `updateChatSessionCategory(sessionId, category)`.
+   - In `runFollowupChat()`, include `assignment_category: sessionContext.assignmentCategory ?? ""` in the chat stream JSON body.
+   - In `runGuideRegeneration()`, include the same field so regenerated guides can receive category-aware framing too.
+
+9. Update webapp UI labels.
+   - Add a small category label beside the `Session Chat` header on `webapp/src/app/dashboard/chat/page.tsx`.
+   - Add a small category label beside the chat name in `webapp/src/components/chat/chat-session-list.tsx`.
+   - Add `classifying_assignment` to the visible stage label map so the loading/progress animation reads `Classifying assignment`.
+
+10. Add agent service tests.
+   - New `agent_service/tests/unit/test_classification_service.py` covering valid label, invalid label fallback, empty output fallback, and exception fallback.
+   - Add or update run-agent tests to assert `run.completed` includes `assignment_category` and chat workflow passes the field through.
+   - Add `agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py` to verify each category addendum is present and the empty category produces the unchanged base prompt.
+
+11. Review and update documentation.
+    - `agent_service/ARCHITECTURE.md`: document classification as a post-guide streaming step and the `assignment_category` field on `run.completed`.
+    - `webapp/ARCHITECTURE.md`: document persisted session category and follow-up chat request threading.
+    - `README.md` and `internal/architecture/*`: scan for stale run/chat contracts; update only if they describe the affected flow.
+
+## Files to Modify
+
+- `supabase/migrations/<timestamp>_add_chat_session_assignment_category.sql` - add nullable checked category column.
+- `agent_service/app/services/classification_service.py` - new fail-open LLM classification service.
+- `agent_service/app/services/run_agent_service.py` - stream classification stage, include category in completion, and pass category into chat.
+- `agent_service/app/schemas/requests.py` - extend `ChatStreamRequest`.
+- `agent_service/app/orchestrators/headstart_orchestrator.py` - category addenda and prompt selection.
+- `webapp/src/lib/chat-repository.ts` - DB type/select/update category handling.
+- `webapp/src/lib/chat-types.ts` - persisted snapshot and stage type updates.
+- `webapp/src/lib/chat-session-runner.ts` - persist initial category and pass it to chat/regeneration.
+- `webapp/src/app/dashboard/chat/page.tsx` - session header category label.
+- `webapp/src/components/chat/chat-session-list.tsx` - chat-list category label.
+- `webapp/src/lib/chat-utils.ts` - stage/category display helpers.
+- `agent_service/tests/unit/test_classification_service.py` - new classifier tests.
+- `agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py` - new prompt tests.
+- `agent_service/tests/unit/test_run_agent_service.py` - update stream/event pass-through tests.
+- `agent_service/ARCHITECTURE.md` - classification/run contract docs.
+- `webapp/ARCHITECTURE.md` - persistence/chat contract docs.
+- Possibly `README.md` or `internal/architecture/*` if they contain stale run/chat contract descriptions.
+
+## Testing Strategy
+
+- Existing tests to update:
+  - `agent_service/tests/unit/test_run_agent_service.py` for classification stage/completion payload and chat pass-through.
+  - Any webapp type-level checks affected by `PersistedSessionSnapshot` and `ChatSessionStage`.
+
+- New tests to write:
+  - `agent_service/tests/unit/test_classification_service.py`.
+  - `agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py`.
+
+- Commands to run:
+  - Inspect available scripts first: `npm run` in `webapp/`.
+  - Agent unit tests for touched modules, likely `python -m pytest agent_service/tests/unit/test_classification_service.py agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py agent_service/tests/unit/test_run_agent_service.py`.
+  - Agent lint/type checks if configured, such as `ruff` and `mypy`.
+  - Webapp type check/build command available in `webapp/package.json`, likely `npm run build` or `npm run typecheck`.
+
+- Manual verification:
+  - Apply the migration to a local Supabase database.
+  - Trigger initial guide generation for representative coding and math assignments.
+  - Inspect `public.chat_sessions.assignment_category`.
+  - Confirm the final `run.completed` SSE payload includes `assignment_category`.
+  - Send a follow-up chat and confirm the agent service receives and applies the expected category addendum.
+  - Simulate classifier failure and confirm guide generation still completes and chat uses the base prompt.
+
+## Safety Checklist
+
+- [ ] Canvas assignment data handled appropriately
+- [ ] Attachment processing bounded and resilient
+- [ ] Chat/session context preserved
+- [ ] Cross-service API contracts compatible
+- [ ] Streaming states covered
+- [ ] User-visible errors are clear
+- [ ] No secrets committed
+- [ ] Calendar behavior preserved
+
+## Complexity
+
+**Size:** Medium
+**Files changed:** ~12-14
+**Notes:** This is a coordinated contract change across agent streaming, webapp persistence, and the database. The main risks are classification latency delaying `run.completed`, provider errors affecting a successful guide run, and category-specific addenda drifting into submission-ready help. The implementation should treat classification as best-effort and keep old `NULL` sessions fully compatible.
+
+## Completion Summary
+
+Implemented:
+
+- Added best-effort assignment classification service using NVIDIA GPT-OSS 120B.
+- Added category-specific follow-up chat system prompt addenda for coding, mathematics, science, speech, and essay.
+- Added `classifying_assignment` streaming stage with user-facing loading text `Classifying assignment` before guide generation begins.
+- Added `assignment_category` to `run.completed` and optional `ChatStreamRequest`.
+- Persisted category metadata on chat sessions and passed it into follow-up chat / guide regeneration.
+- Rendered category labels beside the chat session header and chat names in the chats list.
+- Added Supabase migration `supabase/migrations/20260425_add_chat_session_assignment_category.sql`.
+- Updated agent/webapp architecture docs and streaming details.
+- Added classifier, prompt, and run-service unit tests.
+
+Verification run:
+
+- `agent_service/myenv/Scripts/python.exe -m unittest discover -s tests` - passed, 46 tests.
+- `python -m unittest tests.unit.test_classification_service tests.unit.test_headstart_orchestrator_category_prompts tests.unit.test_run_agent_service` - passed, 17 tests.
+- `npm run lint` in `webapp/` - passed.
+- `npm run build` in `webapp/` - passed.
+- `python -m ruff check app tests` - not available; `ruff` is not installed.
+- `python -m mypy app tests` - not available; `mypy` is not installed.
+
+Additional build hygiene:
+
+- Fixed existing webapp lint/type blockers found during verification:
+  - escaped/rewrote two JSX apostrophe strings,
+  - removed one unused upload constant,
+  - narrowed a guide-version cache value before state update,
+  - removed unsupported `className` prop from `FullCalendar`.
+
+Commits:
+
+- Not created. `git add` failed with `.git/index.lock` permission denial, and the escalation request to stage files was rejected.

--- a/agent_service/ARCHITECTURE.md
+++ b/agent_service/ARCHITECTURE.md
@@ -9,6 +9,7 @@ The FastAPI agent service receives normalized assignment payloads (plus optional
 - `app/main.py`: FastAPI entrypoint, route registration, legacy compatibility endpoints.
 - `app/api/v1/routes/runs.py`: Request handler wrapper for run execution.
 - `app/services/run_agent_service.py`: Request-level workflow orchestration.
+- `app/services/classification_service.py`: Best-effort assignment category classifier used after streamed guide generation.
 - `app/services/pdf_text_service.py`: Page-aware PDF extraction (native-first classification, selective OCR fallback, normalization, visual-significance extraction).
 - `app/orchestrators/headstart_orchestrator.py`: LLM prompting, structured parsing, and streaming guide/chat generation.
 - `app/clients/llm_client.py`: LLM client factory for NVIDIA-hosted `openai/gpt-oss-120b` via LangChain.
@@ -84,6 +85,8 @@ Both run endpoints share the same internal handler path through `handle_run_agen
 13. If needed, orchestrator falls back to prompt-based generation with JSON repair/parsing heuristics.
 14. Service returns structured dictionary back through route layer.
 
+For streamed guide generation, the service extracts assignment context, emits a `classifying_assignment` stage, then calls the lightweight classifier before guide generation begins. The final `run.completed` SSE payload includes `assignment_category` as structured metadata. Classification is fail-open and returns `general` if provider setup, output parsing, or the LLM call fails.
+
 ## PDF Extraction Strategy
 
 - Native text extraction is the default path for highest fidelity when a text layer exists.
@@ -97,6 +100,8 @@ Both run endpoints share the same internal handler path through `handle_run_agen
 
 - Preferred streaming mode: NVIDIA-hosted `openai/gpt-oss-120b` through LangChain `ChatNVIDIA.stream`.
 - Streaming mode emits provider chunks directly for long-lived guide and chat responses.
+- Initial streamed runs perform a short post-guide classification call with the same hosted model to produce one of `coding`, `mathematics`, `science`, `speech`, `essay`, or `general`.
+- Follow-up chat prompts append an internal category-specific system prompt addendum when a recognized category is supplied by the webapp. The category is metadata and is not rendered into assistant chat responses.
 - Legacy non-stream primary mode: schema-bound structured output for reliable contract adherence.
 - Legacy non-stream fallback mode: strict JSON prompt with retries (`MAX_RETRIES`) and parser repair.
 - Parsing safeguards: markdown fence stripping, quote normalization, trailing comma cleanup, control-character cleanup, key quoting heuristics.
@@ -121,3 +126,4 @@ Both run endpoints share the same internal handler path through `handle_run_agen
 - Visual-signal extraction failures are logged and skipped per page/file; text extraction and run generation continue.
 - Route wrapper catches unhandled workflow exceptions and returns HTTP 500.
 - Parsing failures after all retries raise explicit runtime errors with diagnostics.
+- Assignment classification failures do not fail guide generation; the service emits `general` and keeps the chat prompt on the base behavior.

--- a/agent_service/app/orchestrators/headstart_orchestrator.py
+++ b/agent_service/app/orchestrators/headstart_orchestrator.py
@@ -949,10 +949,76 @@ def _format_calendar_context_for_prompt(calendar_context: Optional[dict]) -> str
     return text
 
 
-def _build_followup_chat_prompt() -> ChatPromptTemplate:
+CATEGORY_PROMPT_ADDENDA: dict[str, str] = {
+    "coding": """\
+## Assignment-Type Guidance: Coding
+- Frame help around problem decomposition, input/output contracts, data structures, algorithms,
+  pseudocode, testing strategy, debugging workflow, and implementation milestones.
+- When the student shares code, review it for conceptual errors, edge cases, readability, and tests.
+- You may provide small illustrative snippets, but do not write a complete submission-ready program
+  or fill in the assignment's final solution for the student.
+- Encourage the student to explain their current approach, expected behavior, observed behavior,
+  and error messages before proposing next debugging steps.\
+""",
+    "mathematics": """\
+## Assignment-Type Guidance: Mathematics
+- Frame help around definitions, known givens, target claims, notation, theorem selection, proof
+  structure, worked setup, units, and sanity checks.
+- Show how to start and verify reasoning without giving final numeric answers, full derivations,
+  or complete proofs for assigned problems.
+- When checking a student's attempt, identify the first incorrect or unsupported step and suggest
+  a focused correction path.
+- Encourage the student to state assumptions, intermediate results, and what rule or theorem they
+  are trying to use.\
+""",
+    "science": """\
+## Assignment-Type Guidance: Science
+- Frame help around core concepts, hypotheses, variables, methods, evidence, units, data quality,
+  lab/report structure, and interpretation of results.
+- Help the student connect observations to scientific reasoning without fabricating data or writing
+  a finished lab report or research response.
+- For calculations or analysis, emphasize setup, assumptions, dimensional checks, uncertainty, and
+  what conclusion the evidence can support.
+- If safety, ethics, or experimental constraints appear in the assignment, keep those constraints
+  visible in the next steps.\
+""",
+    "speech": """\
+## Assignment-Type Guidance: Speech
+- Frame help around audience, purpose, thesis, structure, transitions, evidence, timing, delivery,
+  visual aids, speaker notes, and rehearsal strategy.
+- Help the student outline, refine, and practice the speech without writing a complete script for
+  them unless they provide their own draft for feedback.
+- When reviewing a draft or outline, focus on clarity, flow, support, pacing, and memorable openings
+  or closings.
+- Suggest practice tactics such as timed runs, cue cards, slide checks, and audience-aware wording.\
+""",
+    "essay": """\
+## Assignment-Type Guidance: Essay
+- Frame help around prompt interpretation, thesis development, claims, evidence, paragraph
+  structure, source use, citations, revision, and rubric alignment.
+- Help the student brainstorm, outline, critique, and revise without writing submission-ready
+  paragraphs or a complete essay for them.
+- When reviewing a student's draft, identify thesis clarity, argument gaps, organization issues,
+  evidence quality, and concrete revision priorities.
+- Encourage the student to connect each paragraph to the thesis and distinguish their own analysis
+  from source summary.\
+""",
+}
+
+
+def _normalize_prompt_category(assignment_category: str = "") -> str:
+    category = (assignment_category or "").strip().lower()
+    return category if category in CATEGORY_PROMPT_ADDENDA else ""
+
+
+def _build_followup_chat_prompt(assignment_category: str = "") -> ChatPromptTemplate:
+    category = _normalize_prompt_category(assignment_category)
+    system_prompt = SYSTEM_PROMPT_CHAT
+    if category:
+        system_prompt = f"{SYSTEM_PROMPT_CHAT}\n\n{CATEGORY_PROMPT_ADDENDA[category]}"
     return ChatPromptTemplate.from_messages(
         [
-            ("system", SYSTEM_PROMPT_CHAT),
+            ("system", system_prompt),
             ("human", HUMAN_TEMPLATE_CHAT),
         ]
     )
@@ -961,6 +1027,7 @@ def _build_followup_chat_prompt() -> ChatPromptTemplate:
 def stream_headstart_chat_answer(
     assignment_payload: dict,
     guide_markdown: str,
+    assignment_category: str = "",
     chat_history: Optional[list[dict]] = None,
     retrieval_context: Optional[list[dict]] = None,
     user_message: str = "",
@@ -990,7 +1057,7 @@ def stream_headstart_chat_answer(
         max_tokens=MAX_OUTPUT_TOKENS,
         top_p=TOP_P,
     )
-    prompt = _build_followup_chat_prompt()
+    prompt = _build_followup_chat_prompt(assignment_category)
 
     sanitized_payload = _sanitize_assignment_payload_for_chat(assignment_payload or {})
     payload_str = _truncate_for_chat(

--- a/agent_service/app/schemas/requests.py
+++ b/agent_service/app/schemas/requests.py
@@ -94,6 +94,7 @@ class CalendarContext(BaseModel):
 
 class ChatStreamRequest(BaseModel):
     assignment_payload: Dict[str, Any]
+    assignment_category: Optional[str] = ""
     guide_markdown: str = ""
     chat_history: List[ChatHistoryMessage] = Field(default_factory=list)
     retrieval_context: List[RetrievalChunk] = Field(default_factory=list)

--- a/agent_service/app/services/classification_service.py
+++ b/agent_service/app/services/classification_service.py
@@ -1,0 +1,113 @@
+"""
+Artifact: agent_service/app/services/classification_service.py
+Purpose: Classifies assignments into broad follow-up chat prompt categories.
+"""
+
+import json
+import re
+from typing import Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from ..clients.llm_client import STRICT_GUIDE_MODEL_ID, build_nvidia_chat_client
+from ..core.logging import get_logger
+
+logger = get_logger("headstart.classification")
+
+ASSIGNMENT_CATEGORIES = {"coding", "mathematics", "science", "speech", "essay", "general"}
+CLASSIFIER_TEMPERATURE = 0.2
+CLASSIFIER_TOP_P = 1
+CLASSIFIER_MAX_TOKENS = 64
+MAX_CLASSIFICATION_PAYLOAD_CHARS = 5000
+MAX_CLASSIFICATION_PDF_CHARS = 5000
+
+CLASSIFICATION_SYSTEM_PROMPT = """\
+You classify Canvas assignments for an academic support application.
+
+Return exactly one lowercase label from this list:
+coding, mathematics, science, speech, essay, general
+
+Use the best fit:
+- coding: programming, software, data structures, algorithms, notebooks, scripts, debugging.
+- mathematics: calculations, proofs, problem sets, statistics theory, symbolic reasoning.
+- science: lab reports, experiments, scientific concepts, data analysis, research summaries.
+- speech: presentations, speeches, slide talks, oral delivery, debate speaking.
+- essay: essays, papers, reflections, literary analysis, argument-driven writing.
+- general: anything that does not clearly fit one category.
+
+Do not explain your choice. Do not output JSON.\
+"""
+
+
+def _to_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_to_text(item) for item in value)
+    content = getattr(value, "content", None)
+    if content is not None:
+        return _to_text(content)
+    return str(value)
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    text = (value or "").strip()
+    if len(text) <= max_chars:
+        return text
+    return f"{text[:max_chars]}\n...[truncated {len(text) - max_chars} chars]"
+
+
+def normalize_assignment_category(raw: str) -> str:
+    text = (raw or "").strip().lower()
+    if not text:
+        return "general"
+    match = re.search(r"\b(coding|mathematics|science|speech|essay|general)\b", text)
+    if not match:
+        return "general"
+    category = match.group(1)
+    return category if category in ASSIGNMENT_CATEGORIES else "general"
+
+
+def classify_assignment(payload: dict, pdf_text: str = "") -> str:
+    """
+    Return an assignment category label.
+
+    Classification is intentionally fail-open: guide generation and follow-up chat
+    must continue even if provider setup, auth, networking, or output parsing fails.
+    """
+    try:
+        payload_str = _truncate(
+            json.dumps(payload or {}, ensure_ascii=False, default=str),
+            MAX_CLASSIFICATION_PAYLOAD_CHARS,
+        )
+        pdf_text_str = _truncate(pdf_text or "", MAX_CLASSIFICATION_PDF_CHARS)
+        llm = build_nvidia_chat_client(
+            model_name=STRICT_GUIDE_MODEL_ID,
+            temperature=CLASSIFIER_TEMPERATURE,
+            max_tokens=CLASSIFIER_MAX_TOKENS,
+            top_p=CLASSIFIER_TOP_P,
+        )
+        response = llm.invoke(
+            [
+                SystemMessage(content=CLASSIFICATION_SYSTEM_PROMPT),
+                HumanMessage(
+                    content=(
+                        "Assignment payload:\n"
+                        f"{payload_str}\n\n"
+                        "Extracted assignment file text:\n"
+                        f"{pdf_text_str or '(none)'}"
+                    )
+                ),
+            ]
+        )
+        category = normalize_assignment_category(_to_text(response))
+        if category == "general":
+            logger.info("Assignment classification returned general/fallback")
+        else:
+            logger.info("Assignment classified | category=%s", category)
+        return category
+    except Exception as exc:
+        logger.warning("Assignment classification failed; using general category: %s", repr(exc))
+        return "general"

--- a/agent_service/app/services/run_agent_service.py
+++ b/agent_service/app/services/run_agent_service.py
@@ -58,6 +58,7 @@ def _stream_headstart_agent_markdown(
 
 def _stream_headstart_chat_answer(
     assignment_payload: dict,
+    assignment_category: str,
     guide_markdown: str,
     chat_history: list[dict],
     retrieval_context: list[dict],
@@ -72,6 +73,7 @@ def _stream_headstart_chat_answer(
 
     return stream_headstart_chat_answer(
         assignment_payload=assignment_payload,
+        assignment_category=assignment_category,
         guide_markdown=guide_markdown,
         chat_history=chat_history,
         retrieval_context=retrieval_context,
@@ -81,6 +83,13 @@ def _stream_headstart_chat_answer(
         assignment_pdf_text=assignment_pdf_text,
         user_attachments_context=user_attachments_context,
     )
+
+
+def _classify_assignment(payload: dict, pdf_text: str) -> str:
+    """Lazy import to keep classifier dependencies off import-time paths."""
+    from .classification_service import classify_assignment
+
+    return classify_assignment(payload, pdf_text)
 
 
 def run_agent_workflow(req: RunAgentRequest, route_path: str) -> dict:
@@ -223,6 +232,16 @@ def stream_run_agent_workflow(req: RunAgentRequest, route_path: str) -> Generato
         yield _build_event(
             "run.stage",
             {
+                "stage": "classifying_assignment",
+                "progress_percent": 48,
+                "status_message": "Classifying assignment",
+            },
+        )
+        assignment_category = _classify_assignment(req.payload, pdf_text)
+
+        yield _build_event(
+            "run.stage",
+            {
                 "stage": "calling_agent",
                 "progress_percent": 56,
                 "status_message": "Calling AI generation service",
@@ -284,12 +303,14 @@ def stream_run_agent_workflow(req: RunAgentRequest, route_path: str) -> Generato
         ).model_dump()
 
         logger.info(
-            "Streaming agent completed | markdown_len=%d reasoning_len=%d",
+            "Streaming agent completed | markdown_len=%d reasoning_len=%d assignment_category=%s",
             len(guide_markdown),
             reasoning_char_count,
+            assignment_category,
         )
         completed_payload = {
             **result,
+            "assignment_category": assignment_category,
             "stage": "completed",
             "progress_percent": 100,
             "status_message": "Guide ready",
@@ -421,6 +442,7 @@ def stream_chat_workflow(req: ChatStreamRequest, route_path: str) -> Generator[d
 
         for chunk in _stream_headstart_chat_answer(
             assignment_payload=req.assignment_payload,
+            assignment_category=req.assignment_category or "",
             guide_markdown=req.guide_markdown,
             chat_history=[item.model_dump() for item in req.chat_history],
             retrieval_context=[item.model_dump() for item in req.retrieval_context],

--- a/agent_service/streaming_details.md
+++ b/agent_service/streaming_details.md
@@ -42,9 +42,10 @@ Events are emitted in this order (with repeats where noted):
 
 1. `run.started`
 2. `run.stage` (for deterministic stage transitions)
-3. `run.delta` (repeated while model output streams)
-4. `run.stage` (`validating_output`)
-5. `run.completed`
+3. `run.stage` (`classifying_assignment`)
+4. `run.delta` (repeated while model output streams)
+5. `run.stage` (`validating_output`)
+6. `run.completed`
 
 Failure path:
 
@@ -62,7 +63,7 @@ Failure path:
 ### `run.stage`
 - Purpose: stage-level progress updates.
 - Includes:
-  - `stage` (`preparing_payload`, `extracting_pdf`, `calling_agent`, `validating_output`, etc.)
+  - `stage` (`preparing_payload`, `extracting_pdf`, `calling_agent`, `validating_output`, `classifying_assignment`, etc.)
   - `progress_percent`
   - `status_message`
 
@@ -82,6 +83,7 @@ Failure path:
 - Purpose: terminal success event.
 - Includes:
   - `guideMarkdown` (full final markdown body)
+  - `assignment_category` (`coding`, `mathematics`, `science`, `speech`, `essay`, or `general`)
   - `thinking_content` (optional full streamed thinking trace)
   - `stage` (`completed`)
   - `progress_percent` (`100`)
@@ -104,6 +106,8 @@ The orchestrator includes a dedicated streaming markdown path:
 - Emits provider content chunks as they arrive instead of buffering a single response object.
 - Streams optional provider reasoning chunks separately when thinking output is enabled.
 - Final output is normalized and validated before `run.completed`.
+- After PDF/context extraction and before guide generation, the service performs a best-effort lightweight assignment classification call.
+  Classification failures emit `assignment_category: "general"` instead of failing the completed guide.
 
 This keeps the dashboard rendering progressively for long-running guide generation.
 

--- a/agent_service/tests/unit/test_classification_service.py
+++ b/agent_service/tests/unit/test_classification_service.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest.mock import patch
+
+from app.services.classification_service import classify_assignment, normalize_assignment_category
+
+
+class FakeClassificationClient:
+    def __init__(self, response):
+        self.response = response
+        self.invoke_calls = []
+
+    def invoke(self, messages):
+        self.invoke_calls.append(messages)
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+class FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class TestClassificationService(unittest.TestCase):
+    def test_normalize_assignment_category_accepts_known_label(self):
+        self.assertEqual(normalize_assignment_category("Coding\n"), "coding")
+        self.assertEqual(normalize_assignment_category("The category is mathematics."), "mathematics")
+
+    def test_normalize_assignment_category_falls_back_for_unknown_label(self):
+        self.assertEqual(normalize_assignment_category("history"), "general")
+        self.assertEqual(normalize_assignment_category(""), "general")
+
+    def test_classify_assignment_returns_valid_label(self):
+        fake_client = FakeClassificationClient(FakeMessage("essay"))
+
+        with patch(
+            "app.services.classification_service.build_nvidia_chat_client",
+            return_value=fake_client,
+        ):
+            category = classify_assignment(
+                {"title": "Rhetorical Analysis", "descriptionText": "Write an essay."},
+                "",
+            )
+
+        self.assertEqual(category, "essay")
+        self.assertEqual(len(fake_client.invoke_calls), 1)
+
+    def test_classify_assignment_falls_back_for_invalid_label(self):
+        fake_client = FakeClassificationClient(FakeMessage("history"))
+
+        with patch(
+            "app.services.classification_service.build_nvidia_chat_client",
+            return_value=fake_client,
+        ):
+            category = classify_assignment({"title": "Timeline project"}, "")
+
+        self.assertEqual(category, "general")
+
+    def test_classify_assignment_falls_back_on_exception(self):
+        fake_client = FakeClassificationClient(RuntimeError("provider unavailable"))
+
+        with patch(
+            "app.services.classification_service.build_nvidia_chat_client",
+            return_value=fake_client,
+        ):
+            category = classify_assignment({"title": "Lab"}, "experiment")
+
+        self.assertEqual(category, "general")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py
+++ b/agent_service/tests/unit/test_headstart_orchestrator_category_prompts.py
@@ -1,0 +1,50 @@
+import unittest
+
+from app.orchestrators.headstart_orchestrator import (
+    CATEGORY_PROMPT_ADDENDA,
+    _build_followup_chat_prompt,
+)
+
+
+PROMPT_VARS = {
+    "payload": "{}",
+    "guide_markdown": "Guide",
+    "retrieval_context": "(none)",
+    "assignment_pdf_text": "(none)",
+    "user_attachments_context": "(none)",
+    "chat_history": "(none)",
+    "calendar_context": "(not provided)",
+    "user_message": "What next?",
+}
+
+
+def system_prompt_text(category: str = "") -> str:
+    prompt = _build_followup_chat_prompt(category)
+    messages = prompt.format_messages(**PROMPT_VARS)
+    return str(messages[0].content)
+
+
+class TestHeadstartOrchestratorCategoryPrompts(unittest.TestCase):
+    def test_empty_category_uses_base_prompt(self):
+        base_text = system_prompt_text("")
+        self.assertEqual(system_prompt_text("general"), base_text)
+        self.assertEqual(system_prompt_text("unknown"), base_text)
+
+    def test_each_category_appends_addendum(self):
+        base_text = system_prompt_text("")
+        for category, addendum in CATEGORY_PROMPT_ADDENDA.items():
+            with self.subTest(category=category):
+                text = system_prompt_text(category)
+                self.assertTrue(text.startswith(base_text))
+                self.assertIn(addendum, text)
+
+    def test_category_addenda_do_not_instruct_visible_label_output(self):
+        for category in CATEGORY_PROMPT_ADDENDA:
+            with self.subTest(category=category):
+                text = system_prompt_text(category).lower()
+                self.assertNotIn("tell the student this category", text)
+                self.assertNotIn("mention the category", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_service/tests/unit/test_run_agent_service.py
+++ b/agent_service/tests/unit/test_run_agent_service.py
@@ -87,6 +87,9 @@ class TestRunAgentService(unittest.TestCase):
                     {"content_delta": "Guide body", "reasoning_delta": "thinking-2"},
                 ]
             ),
+        ), patch(
+            "app.services.run_agent_service._classify_assignment",
+            return_value="coding",
         ):
             events = list(stream_run_agent_workflow(req, route_path="/api/v1/runs/stream"))
 
@@ -100,7 +103,22 @@ class TestRunAgentService(unittest.TestCase):
         self.assertEqual(len(completed_events), 1)
         completed = completed_events[0]["data"]
         self.assertEqual(completed["guideMarkdown"], "Guide body")
+        self.assertEqual(completed["assignment_category"], "coding")
         self.assertEqual(completed["thinking_content"], "thinking-1thinking-2")
+
+        classifying_events = [
+            event
+            for event in events
+            if event.get("event") == "run.stage"
+            and event.get("data", {}).get("stage") == "classifying_assignment"
+        ]
+        self.assertEqual(len(classifying_events), 1)
+        self.assertEqual(classifying_events[0]["data"]["status_message"], "Classifying assignment")
+        classifying_index = events.index(classifying_events[0])
+        first_delta_index = next(
+            index for index, event in enumerate(events) if event.get("event") == "run.delta"
+        )
+        self.assertLess(classifying_index, first_delta_index)
 
     def test_stream_chat_workflow_emits_reasoning_deltas_and_completion_thinking(self):
         req = ChatStreamRequest(
@@ -135,6 +153,7 @@ class TestRunAgentService(unittest.TestCase):
         self.assertEqual(completed["thinking_content"], "think-athink-b")
         mock_stream.assert_called_once_with(
             assignment_payload={"title": "HW1"},
+            assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
             retrieval_context=[],
@@ -180,6 +199,7 @@ class TestRunAgentService(unittest.TestCase):
         self.assertEqual(len(completed_events), 1)
         mock_stream.assert_called_once_with(
             assignment_payload={"title": "HW1"},
+            assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
             retrieval_context=[],
@@ -242,6 +262,7 @@ class TestRunAgentService(unittest.TestCase):
         self.assertEqual(len(completed_events), 1)
         mock_stream.assert_called_once_with(
             assignment_payload={"title": "HW1"},
+            assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
             retrieval_context=[],
@@ -276,6 +297,41 @@ class TestRunAgentService(unittest.TestCase):
                     }
                 ],
             },
+            assignment_pdf_text="",
+            user_attachments_context="",
+        )
+
+    def test_stream_chat_workflow_passes_assignment_category(self):
+        req = ChatStreamRequest(
+            assignment_payload={"title": "HW1"},
+            assignment_category="mathematics",
+            guide_markdown="Guide body",
+            chat_history=[],
+            retrieval_context=[],
+            user_message="How should I start?",
+        )
+
+        with patch(
+            "app.services.run_agent_service._stream_headstart_chat_answer",
+            return_value=iter(
+                [
+                    {"content_delta": "Start by naming the givens.", "reasoning_delta": ""},
+                ]
+            ),
+        ) as mock_stream:
+            events = list(stream_chat_workflow(req, route_path="/api/v1/chats/stream"))
+
+        completed_events = [event for event in events if event.get("event") == "chat.completed"]
+        self.assertEqual(len(completed_events), 1)
+        mock_stream.assert_called_once_with(
+            assignment_payload={"title": "HW1"},
+            assignment_category="mathematics",
+            guide_markdown="Guide body",
+            chat_history=[],
+            retrieval_context=[],
+            user_message="How should I start?",
+            include_thinking=False,
+            calendar_context=None,
             assignment_pdf_text="",
             user_attachments_context="",
         )

--- a/supabase/migrations/20260425_add_chat_session_assignment_category.sql
+++ b/supabase/migrations/20260425_add_chat_session_assignment_category.sql
@@ -1,0 +1,23 @@
+ALTER TABLE public.chat_sessions
+  ADD COLUMN IF NOT EXISTS assignment_category text;
+
+DO $$
+BEGIN
+  ALTER TABLE public.chat_sessions
+    ADD CONSTRAINT chat_sessions_assignment_category_check
+    CHECK (
+      assignment_category IS NULL
+      OR assignment_category = ANY (
+        ARRAY[
+          'coding'::text,
+          'mathematics'::text,
+          'science'::text,
+          'speech'::text,
+          'essay'::text,
+          'general'::text
+        ]
+      )
+    );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;

--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -19,6 +19,7 @@ The Next.js web app serves two roles:
 - `src/lib/google-calendar-session.ts`: Token resolution/refresh state handling.
 - `src/lib/google-calendar.ts`: Google Calendar API client (OAuth, list events, create events, revoke, refresh).
 - `src/lib/calendar-google-markers.ts`: Study-block marker contract and classification helpers.
+- `src/lib/chat-session-runner.ts`: Streams guide/chat agent calls, persists guide versions, PDF extraction text, and assignment category metadata.
 
 ## Module Boundaries
 
@@ -93,6 +94,8 @@ The Next.js web app serves two roles:
 
 ## Data and Persistence
 
+- `public.chat_sessions.assignment_category` stores the nullable assignment category returned by the agent service (`coding`, `mathematics`, `science`, `speech`, `essay`, or `general`).
+- The category is shown as a compact label in the chat header and chat list, and is passed back to the agent service for follow-up chat prompt selection.
 - Local planner table `public.assignment_work_blocks` has been removed.
 - Historical create migration: `supabase/migrations/20260325_calendar_work_blocks.sql`.
 - Removal migration: `supabase/migrations/20260326_drop_assignment_work_blocks.sql`.
@@ -115,3 +118,4 @@ The Next.js web app serves two roles:
 - Invalid range/timezone returns `400`.
 - Google 400/401/403 responses transition integration to `needs_attention` and suppress Google events for planner responses.
 - Upstream/network/provider failures map to `500` with error detail.
+- Assignment category persistence is best-effort. If the category is missing or `NULL`, chat sessions continue with the base follow-up prompt and no category label.

--- a/webapp/src/app/api/chat-session/[sessionId]/attachments/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/attachments/route.ts
@@ -13,7 +13,6 @@ export const runtime = "nodejs";
 const CHAT_UPLOAD_BUCKET =
   (process.env.SUPABASE_ASSIGNMENT_PDF_BUCKET ?? "assignment-pdfs");
 const CHAT_UPLOAD_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
-const CHAT_UPLOAD_SIGNED_URL_TTL = 600; // seconds
 
 function bufferToHex(buffer: ArrayBuffer) {
   return Array.from(new Uint8Array(buffer))

--- a/webapp/src/app/api/chat-session/[sessionId]/events/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/events/route.ts
@@ -67,6 +67,7 @@ function applyRuntimeEvent(session: ChatSessionDto, event: RuntimeChatEvent) {
     session.progress_percent = runtime.progressPercent;
     session.status_message = runtime.statusMessage;
     session.streamed_guide_markdown = runtime.streamedGuideMarkdown;
+    session.assignment_category = runtime.assignmentCategory ?? session.assignment_category ?? null;
     session.result = runtime.result ?? session.result;
     session.error = runtime.error ?? null;
     session.updated_at = Math.max(session.updated_at, runtime.updatedAt);
@@ -169,6 +170,7 @@ export async function GET(
               progress_percent: currentSession.progress_percent,
               status_message: currentSession.status_message,
               streamed_guide_markdown: currentSession.streamed_guide_markdown,
+              assignment_category: currentSession.assignment_category,
               result: currentSession.result,
               error: currentSession.error,
               updated_at: currentSession.updated_at,

--- a/webapp/src/app/api/chat-session/route.ts
+++ b/webapp/src/app/api/chat-session/route.ts
@@ -28,6 +28,7 @@ export async function GET(req: Request) {
         session_id: session.sessionId,
         assignment_uuid: session.assignmentUuid,
         title: session.title,
+        assignment_category: session.assignmentCategory,
         last_user_message: session.lastUserMessage,
         status: session.status,
         created_at: session.createdAt,

--- a/webapp/src/app/dashboard/assignments/[slug]/page.tsx
+++ b/webapp/src/app/dashboard/assignments/[slug]/page.tsx
@@ -264,10 +264,11 @@ export default function AssignmentDetailPage() {
         if (typeof body.content_text !== "string") {
           throw new Error("Guide version content missing")
         }
+        const contentText = body.content_text
 
         setGuideContentByVersion((current) => ({
           ...current,
-          [versionNumber]: body.content_text,
+          [versionNumber]: contentText,
         }))
       } catch (error) {
         setGuideVersionError(error instanceof Error ? error.message : "Failed to load guide version.")

--- a/webapp/src/app/dashboard/assignments/page.tsx
+++ b/webapp/src/app/dashboard/assignments/page.tsx
@@ -7,9 +7,11 @@ import { format, formatDistanceToNow } from "date-fns"
 import {
   Search,
   Filter,
+  ArrowUpDown,
   Calendar as CalendarIcon,
   CheckCircle2,
   LoaderCircle,
+  Paperclip,
   RotateCcw,
   Trash2,
 } from "lucide-react"
@@ -25,6 +27,23 @@ import {
 } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import {
   Dialog,
   DialogContent,
@@ -57,6 +76,10 @@ type AssignmentItem = {
   submitted_at: string | null
 }
 
+type DueFilter = "all" | "overdue" | "today" | "week" | "no-date"
+type PriorityFilter = "all" | AssignmentItem["priority"]
+type SortMode = "due" | "updated" | "priority" | "course" | "title"
+
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
 const MAX_COURSE_NAME_LENGTH = 48
 
@@ -64,6 +87,12 @@ function priorityTone(priority: AssignmentItem["priority"]) {
   if (priority === "High") return "border-red-200/80 bg-red-50 text-red-700"
   if (priority === "Medium") return "border-amber-200/80 bg-amber-50 text-amber-700"
   return "border-emerald-200/80 bg-emerald-50 text-emerald-700"
+}
+
+function priorityRailTone(priority: AssignmentItem["priority"]) {
+  if (priority === "High") return "border-l-red-500"
+  if (priority === "Medium") return "border-l-amber-400"
+  return "border-l-emerald-500"
 }
 
 function statusTone(status: AssignmentItem["status"]) {
@@ -85,9 +114,74 @@ function truncateWithEllipsis(value: string, maxLength: number) {
   return `${normalizedValue.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`
 }
 
+function courseNameForFilter(assignment: AssignmentItem) {
+  return assignment.course_name?.trim() || "Unknown course"
+}
+
+function priorityWeight(priority: AssignmentItem["priority"]) {
+  if (priority === "High") return 0
+  if (priority === "Medium") return 1
+  return 2
+}
+
+function isSameLocalDay(left: Date, right: Date) {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  )
+}
+
+function matchesDueFilter(assignment: AssignmentItem, dueFilter: DueFilter) {
+  if (dueFilter === "all") return true
+
+  const dueAt = parseIsoDate(assignment.due_at_iso)
+  if (dueFilter === "no-date") return !dueAt
+  if (!dueAt || assignment.is_submitted) return false
+
+  const now = new Date()
+  if (dueFilter === "overdue") return assignment.is_overdue
+  if (dueFilter === "today") return isSameLocalDay(dueAt, now)
+  if (dueFilter === "week") {
+    const sevenDaysFromNow = now.getTime() + 7 * 24 * 60 * 60 * 1000
+    return dueAt.getTime() >= now.getTime() && dueAt.getTime() <= sevenDaysFromNow
+  }
+
+  return true
+}
+
+function compareDueThenUpdated(left: AssignmentItem, right: AssignmentItem) {
+  if (left.is_submitted !== right.is_submitted) return left.is_submitted ? 1 : -1
+
+  const leftDue = parseIsoDate(left.due_at_iso)?.getTime() ?? null
+  const rightDue = parseIsoDate(right.due_at_iso)?.getTime() ?? null
+  if (leftDue == null && rightDue == null) {
+    return right.latest_session_updated_at - left.latest_session_updated_at
+  }
+  if (leftDue == null) return 1
+  if (rightDue == null) return -1
+  return leftDue - rightDue
+}
+
+function dueSummary(assignment: AssignmentItem, dueAt: Date | null) {
+  if (assignment.is_submitted) {
+    const submittedAt = parseIsoDate(assignment.submitted_at)
+    return submittedAt ? `Submitted ${format(submittedAt, "MMM d, yyyy")}` : "Submitted"
+  }
+
+  if (!dueAt) return "No due date"
+  if (assignment.is_overdue) return `Overdue ${formatDistanceToNow(dueAt, { addSuffix: true })}`
+  return `Due ${formatDistanceToNow(dueAt, { addSuffix: true })}`
+}
+
 export default function AssignmentsPage() {
   const [searchQuery, setSearchQuery] = useState("")
   const [activeTab, setActiveTab] = useState("all")
+  const [selectedCourse, setSelectedCourse] = useState("all")
+  const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>("all")
+  const [dueFilter, setDueFilter] = useState<DueFilter>("all")
+  const [hasAttachmentsOnly, setHasAttachmentsOnly] = useState(false)
+  const [sortMode, setSortMode] = useState<SortMode>("due")
   const [assignments, setAssignments] = useState<AssignmentItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [errorText, setErrorText] = useState<string | null>(null)
@@ -161,8 +255,14 @@ export default function AssignmentsPage() {
     [loadAssignments],
   )
 
+  const courseOptions = useMemo(() => {
+    return Array.from(new Set(assignments.map(courseNameForFilter))).sort((left, right) =>
+      left.localeCompare(right),
+    )
+  }, [assignments])
+
   const filteredAssignments = useMemo(() => {
-    return assignments.filter((assignment) => {
+    const filtered = assignments.filter((assignment) => {
       const query = searchQuery.trim().toLowerCase()
       const matchesSearch =
         query.length === 0 ||
@@ -176,9 +276,54 @@ export default function AssignmentsPage() {
           : activeTab === "completed"
           ? assignment.is_submitted
           : true
-      return matchesSearch && matchesTab
+      const matchesCourse =
+        selectedCourse === "all" || courseNameForFilter(assignment) === selectedCourse
+      const matchesPriority =
+        priorityFilter === "all" || assignment.priority === priorityFilter
+      const matchesAttachments = !hasAttachmentsOnly || assignment.attachment_count > 0
+      return (
+        matchesSearch &&
+        matchesTab &&
+        matchesCourse &&
+        matchesPriority &&
+        matchesDueFilter(assignment, dueFilter) &&
+        matchesAttachments
+      )
     })
-  }, [activeTab, assignments, searchQuery])
+
+    const sorted = filtered.slice()
+    sorted.sort((left, right) => {
+      if (sortMode === "updated") {
+        return right.latest_session_updated_at - left.latest_session_updated_at
+      }
+      if (sortMode === "priority") {
+        const priorityDifference =
+          priorityWeight(left.priority) - priorityWeight(right.priority)
+        return priorityDifference || compareDueThenUpdated(left, right)
+      }
+      if (sortMode === "course") {
+        const courseDifference = courseNameForFilter(left).localeCompare(
+          courseNameForFilter(right),
+        )
+        return courseDifference || compareDueThenUpdated(left, right)
+      }
+      if (sortMode === "title") {
+        return left.title.localeCompare(right.title)
+      }
+      return compareDueThenUpdated(left, right)
+    })
+
+    return sorted
+  }, [
+    activeTab,
+    assignments,
+    dueFilter,
+    hasAttachmentsOnly,
+    priorityFilter,
+    searchQuery,
+    selectedCourse,
+    sortMode,
+  ])
 
   const pendingCount = assignments.filter(
     (assignment) => !assignment.is_submitted,
@@ -189,6 +334,18 @@ export default function AssignmentsPage() {
   const pendingDeleteAssignment = pendingDeleteAssignmentId
     ? assignments.find((assignment) => assignment.id === pendingDeleteAssignmentId) ?? null
     : null
+  const activeFilterCount =
+    (selectedCourse !== "all" ? 1 : 0) +
+    (priorityFilter !== "all" ? 1 : 0) +
+    (dueFilter !== "all" ? 1 : 0) +
+    (hasAttachmentsOnly ? 1 : 0)
+
+  const resetFilters = useCallback(() => {
+    setSelectedCourse("all")
+    setPriorityFilter("all")
+    setDueFilter("all")
+    setHasAttachmentsOnly(false)
+  }, [])
 
   const requestDeleteAssignment = useCallback((assignment: AssignmentItem) => {
     setPendingDeleteAssignmentId(assignment.id)
@@ -249,8 +406,8 @@ export default function AssignmentsPage() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between gap-4">
-          <div className="relative max-w-sm flex-1">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
+          <div className="relative min-w-0">
             <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
             <Input
               type="search"
@@ -260,23 +417,108 @@ export default function AssignmentsPage() {
               onChange={(event) => setSearchQuery(event.target.value)}
             />
           </div>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="icon" aria-label="Assignment filters">
-              <Filter className="h-4 w-4" />
-            </Button>
-          </div>
+
+          <Select value={selectedCourse} onValueChange={setSelectedCourse}>
+            <SelectTrigger className="w-full lg:w-[190px]" aria-label="Filter by course">
+              <SelectValue placeholder="All courses" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All courses</SelectItem>
+              {courseOptions.map((course) => (
+                <SelectItem key={course} value={course}>
+                  {course}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={sortMode} onValueChange={(value) => setSortMode(value as SortMode)}>
+            <SelectTrigger className="w-full lg:w-[180px]" aria-label="Sort assignments">
+              <ArrowUpDown className="h-4 w-4" />
+              <SelectValue placeholder="Sort" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="due">Due soon</SelectItem>
+              <SelectItem value="updated">Recently updated</SelectItem>
+              <SelectItem value="priority">Priority</SelectItem>
+              <SelectItem value="course">Course</SelectItem>
+              <SelectItem value="title">Title A-Z</SelectItem>
+            </SelectContent>
+          </Select>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="justify-center" aria-label="Assignment filters">
+                <Filter className="h-4 w-4" />
+                <span>Filters</span>
+                {activeFilterCount > 0 ? (
+                  <Badge variant="secondary" className="ml-1 px-1.5">
+                    {activeFilterCount}
+                  </Badge>
+                ) : null}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-64">
+              <DropdownMenuLabel>Priority</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={priorityFilter}
+                onValueChange={(value) => setPriorityFilter(value as PriorityFilter)}
+              >
+                <DropdownMenuRadioItem value="all">Any priority</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="High">High</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="Medium">Medium</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="Low">Low</DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Due date</DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={dueFilter}
+                onValueChange={(value) => setDueFilter(value as DueFilter)}
+              >
+                <DropdownMenuRadioItem value="all">Any due date</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="overdue">Overdue</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="today">Due today</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="week">Due this week</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="no-date">No due date</DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuCheckboxItem
+                checked={hasAttachmentsOnly}
+                onCheckedChange={(checked) => setHasAttachmentsOnly(checked === true)}
+                onSelect={(event) => event.preventDefault()}
+              >
+                Has attachments
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start"
+                disabled={activeFilterCount === 0}
+                onClick={resetFilters}
+              >
+                Clear filters
+              </Button>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {errorText ? (
           <p className="text-sm text-destructive">{errorText}</p>
         ) : null}
 
-        <Tabs defaultValue="all" className="w-full" onValueChange={setActiveTab}>
-          <TabsList>
-            <TabsTrigger value="all">All ({assignments.length})</TabsTrigger>
-            <TabsTrigger value="pending">Pending ({pendingCount})</TabsTrigger>
-            <TabsTrigger value="completed">Completed ({completedCount})</TabsTrigger>
-          </TabsList>
+        <Tabs value={activeTab} className="w-full" onValueChange={setActiveTab}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <TabsList>
+              <TabsTrigger value="all">All ({assignments.length})</TabsTrigger>
+              <TabsTrigger value="pending">Pending ({pendingCount})</TabsTrigger>
+              <TabsTrigger value="completed">Completed ({completedCount})</TabsTrigger>
+            </TabsList>
+            <p className="text-sm text-muted-foreground">
+              Showing {filteredAssignments.length} of {assignments.length}
+            </p>
+          </div>
           <TabsContent value="all" className="mt-4">
             <AssignmentList
               assignments={filteredAssignments}
@@ -424,17 +666,42 @@ function AssignmentList({
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.2, ease: EASE_OUT }}
             >
-              <Card className="flex h-full flex-col transition-shadow hover:shadow-md">
-                <CardHeader className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 space-y-0 pb-2">
-                  <div className="min-w-0 space-y-1">
+              <Card
+                className={cn(
+                  "flex h-full overflow-hidden border-l-4 transition-shadow hover:shadow-md",
+                  priorityRailTone(assignment.priority),
+                )}
+              >
+                <CardHeader className="space-y-3 pb-3">
+                  <div className="flex items-start justify-between gap-3">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Badge variant="outline" className="mb-2 max-w-[32ch] shrink justify-start">
+                        <Badge variant="outline" className="max-w-[32ch] shrink justify-start">
                           <span className="block max-w-full truncate">{courseName}</span>
                         </Badge>
                       </TooltipTrigger>
                       <TooltipContent>{fullCourseName}</TooltipContent>
                     </Tooltip>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "shrink-0",
+                        assignment.is_submitted
+                          ? "border-emerald-200/80 bg-emerald-50 text-emerald-700"
+                          : assignment.is_overdue
+                          ? "border-red-200/80 bg-red-50 text-red-700"
+                          : "border-slate-200/80 bg-slate-50 text-slate-700",
+                      )}
+                    >
+                      {assignment.is_submitted
+                        ? "Submitted"
+                        : assignment.is_overdue
+                        ? "Overdue"
+                        : "Open"}
+                    </Badge>
+                  </div>
+
+                  <div className="min-w-0 space-y-2">
                     {assignment.assignment_id ? (
                       <Link href={`/dashboard/assignments/${encodeURIComponent(assignment.assignment_id)}`}>
                         <CardTitle className="line-clamp-2 break-words text-base leading-snug hover:text-primary hover:underline" title={assignment.title}>
@@ -446,56 +713,38 @@ function AssignmentList({
                         {assignment.title}
                       </CardTitle>
                     )}
-                    <CardDescription className="text-xs">
-                      Attachments: {assignment.attachment_count}
+                    <CardDescription className="flex items-center gap-1 text-xs">
+                      <Paperclip className="h-3.5 w-3.5" />
+                      <span>{assignment.attachment_count} attachments</span>
                     </CardDescription>
                   </div>
-                  <div className="flex shrink-0 items-center gap-1 self-start">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          aria-label={submitTooltip}
-                          disabled={!assignment.assignment_id || isUpdating || isDeleting}
-                          onClick={() => void onToggleSubmitted(assignment)}
-                        >
-                          {isUpdating ? (
-                            <LoaderCircle className="h-4 w-4 animate-spin" />
-                          ) : assignment.is_submitted ? (
-                            <RotateCcw className="h-4 w-4" />
-                          ) : (
-                            <CheckCircle2 className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>{submitTooltip}</TooltipContent>
-                    </Tooltip>
-
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon"
-                          className="text-destructive hover:text-destructive"
-                          aria-label="Delete assignment"
-                          disabled={!assignment.assignment_id || isDeleting}
-                          onClick={() => onRequestDeleteAssignment(assignment)}
-                        >
-                          {isDeleting ? (
-                            <LoaderCircle className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <Trash2 className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Delete assignment</TooltipContent>
-                    </Tooltip>
-                  </div>
                 </CardHeader>
-                <CardContent className="mt-auto space-y-3 pt-4">
+                <CardContent className="mt-auto space-y-4 pt-0">
+                  <div
+                    className={cn(
+                      "flex items-start gap-2 rounded-md border px-3 py-2 text-sm",
+                      assignment.is_submitted
+                        ? "border-emerald-200/80 bg-emerald-50 text-emerald-800"
+                        : assignment.is_overdue
+                        ? "border-red-200/80 bg-red-50 text-red-700"
+                        : "border-border/70 bg-muted/20 text-muted-foreground",
+                    )}
+                  >
+                    {assignment.is_submitted ? (
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+                    ) : (
+                      <CalendarIcon className="mt-0.5 h-4 w-4 shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <p className="font-medium">{dueSummary(assignment, dueAt)}</p>
+                      {!assignment.is_submitted && dueAt ? (
+                        <p className="text-xs opacity-80">
+                          {format(dueAt, "MMM d, yyyy h:mm a")}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+
                   <div className="flex flex-wrap items-center gap-2">
                     <Badge variant="outline" className={cn(priorityTone(assignment.priority))}>
                       {assignment.priority}
@@ -505,28 +754,64 @@ function AssignmentList({
                     </Badge>
                   </div>
 
-                  {assignment.is_submitted ? (
-                    <div className="inline-flex w-fit items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 py-1 text-sm font-semibold text-emerald-800">
-                      <CheckCircle2 className="h-4 w-4" />
-                      <span>Submitted</span>
+                  <div className="flex items-center justify-between gap-2 border-t border-border/70 pt-3">
+                    {assignment.assignment_id ? (
+                      <Button asChild variant="outline" size="sm">
+                        <Link href={`/dashboard/assignments/${encodeURIComponent(assignment.assignment_id)}`}>
+                          Open
+                        </Link>
+                      </Button>
+                    ) : (
+                      <Button variant="outline" size="sm" disabled>
+                        Open
+                      </Button>
+                    )}
+
+                    <div className="flex items-center gap-1">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            aria-label={submitTooltip}
+                            disabled={!assignment.assignment_id || isUpdating || isDeleting}
+                            onClick={() => void onToggleSubmitted(assignment)}
+                          >
+                            {isUpdating ? (
+                              <LoaderCircle className="h-4 w-4 animate-spin" />
+                            ) : assignment.is_submitted ? (
+                              <RotateCcw className="h-4 w-4" />
+                            ) : (
+                              <CheckCircle2 className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{submitTooltip}</TooltipContent>
+                      </Tooltip>
+
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="text-destructive hover:text-destructive"
+                            aria-label="Delete assignment"
+                            disabled={!assignment.assignment_id || isDeleting}
+                            onClick={() => onRequestDeleteAssignment(assignment)}
+                          >
+                            {isDeleting ? (
+                              <LoaderCircle className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="h-4 w-4" />
+                            )}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Delete assignment</TooltipContent>
+                      </Tooltip>
                     </div>
-                  ) : (
-                    <div
-                      className={cn(
-                        "flex items-center gap-1 text-sm",
-                        assignment.is_overdue ? "text-destructive" : "text-muted-foreground",
-                      )}
-                    >
-                      <CalendarIcon className="h-4 w-4" />
-                      {dueAt ? (
-                        <span>
-                          {format(dueAt, "MMM d, yyyy h:mm a")} ({formatDistanceToNow(dueAt, { addSuffix: true })})
-                        </span>
-                      ) : (
-                        <span>No due date available</span>
-                      )}
-                    </div>
-                  )}
+                  </div>
                 </CardContent>
               </Card>
             </motion.div>

--- a/webapp/src/app/dashboard/calendar/page.tsx
+++ b/webapp/src/app/dashboard/calendar/page.tsx
@@ -332,7 +332,6 @@ export default function DashboardCalendarPage() {
           <CardContent>
             <div className="headstart-calendar-shell__frame relative rounded-2xl border border-border/70 bg-background/80 p-2.5 sm:p-3">
               <FullCalendar
-                className="headstart-calendar-shell__calendar"
                 plugins={[dayGridPlugin]}
                 initialView="dayGridMonth"
                 height="auto"

--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -25,6 +25,7 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
 import {
+  assignmentCategoryLabel,
   extractGuideMarkdown,
   formatDateTime,
   removeThinkBlocks,
@@ -51,6 +52,7 @@ const GUIDE_PROGRESS_STAGES = new Set([
   "calling_agent",
   "streaming_output",
   "validating_output",
+  "classifying_assignment",
   "parsing_response",
 ])
 
@@ -540,6 +542,7 @@ function DashboardChatPageContent() {
     }
     return "New Chat"
   }, [effectiveSession])
+  const categoryLabel = assignmentCategoryLabel(effectiveSession?.assignment_category)
 
   async function handleRegenerateGuide() {
     if (!sessionId || !effectiveSession || isRegenerating) return
@@ -679,6 +682,14 @@ function DashboardChatPageContent() {
       >
         <div className="min-w-0 flex items-center gap-2">
           <h1 className="text-lg font-heading font-medium tracking-tight">Session Chat</h1>
+          {categoryLabel ? (
+            <Badge
+              variant="outline"
+              className="w-fit border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-200"
+            >
+              {categoryLabel}
+            </Badge>
+          ) : null}
           {effectiveSession ? (
             <Badge
               variant="outline"

--- a/webapp/src/app/dashboard/chat/page.tsx
+++ b/webapp/src/app/dashboard/chat/page.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/breadcrumb"
 import {
   assignmentCategoryLabel,
+  assignmentCategoryTone,
   extractGuideMarkdown,
   formatDateTime,
   removeThinkBlocks,
@@ -543,6 +544,7 @@ function DashboardChatPageContent() {
     return "New Chat"
   }, [effectiveSession])
   const categoryLabel = assignmentCategoryLabel(effectiveSession?.assignment_category)
+  const categoryTone = assignmentCategoryTone(effectiveSession?.assignment_category)
 
   async function handleRegenerateGuide() {
     if (!sessionId || !effectiveSession || isRegenerating) return
@@ -685,7 +687,7 @@ function DashboardChatPageContent() {
           {categoryLabel ? (
             <Badge
               variant="outline"
-              className="w-fit border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-200"
+              className={`w-fit px-2 py-0.5 text-[10px] ${categoryTone}`}
             >
               {categoryLabel}
             </Badge>

--- a/webapp/src/app/not-found.tsx
+++ b/webapp/src/app/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
         <h1 className="text-4xl font-heading font-bold tracking-tight sm:text-6xl">404</h1>
         <h2 className="text-2xl font-sans font-bold tracking-tight">Page Not Found</h2>
         <p className="text-muted-foreground text-lg">
-          Whoops! Looks like this page hasn't been generated yet. Even our AI is scratching its head.
+          Whoops! Looks like this page has not been generated yet. Even our AI is scratching its head.
         </p>
       </div>
 

--- a/webapp/src/components/chat/calendar-proposal-card.tsx
+++ b/webapp/src/components/chat/calendar-proposal-card.tsx
@@ -162,7 +162,7 @@ export function CalendarProposalCard({
                 transition={{ duration: 0.15 }}
               >
                 <p className="mb-3 text-xs text-muted-foreground">
-                  Select the sessions you'd like to add to Google Calendar:
+                  Select the sessions you would like to add to Google Calendar:
                 </p>
 
                 <div className="space-y-2">

--- a/webapp/src/components/chat/chat-session-list.tsx
+++ b/webapp/src/components/chat/chat-session-list.tsx
@@ -17,7 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { formatDateTime } from "@/lib/chat-utils"
+import { assignmentCategoryLabel, formatDateTime } from "@/lib/chat-utils"
 import { type ChatSessionStatus } from "@/lib/chat-types"
 
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
@@ -26,6 +26,7 @@ type ChatSessionListItemResponse = {
   session_id: string
   assignment_uuid: string
   title: string
+  assignment_category?: string | null
   last_user_message?: string | null
   status: ChatSessionStatus
   created_at: number
@@ -438,6 +439,7 @@ export function ChatSessionList() {
                                 item.last_user_message.trim().length > 0
                                   ? item.last_user_message.trim()
                                   : "Chat Session"
+                              const categoryLabel = assignmentCategoryLabel(item.assignment_category)
                               const isDeleting = deletingSessionIds.has(item.session_id)
 
                               return (
@@ -469,9 +471,19 @@ export function ChatSessionList() {
                                       disabled={isDeleting}
                                     >
                                       <div className="flex flex-wrap items-start justify-between gap-2">
-                                        <p className="truncate text-sm font-medium text-foreground">
-                                          {sessionLabel}
-                                        </p>
+                                        <div className="min-w-0 flex flex-wrap items-center gap-1.5">
+                                          <p className="truncate text-sm font-medium text-foreground">
+                                            {sessionLabel}
+                                          </p>
+                                          {categoryLabel ? (
+                                            <Badge
+                                              variant="outline"
+                                              className="shrink-0 border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-200"
+                                            >
+                                              {categoryLabel}
+                                            </Badge>
+                                          ) : null}
+                                        </div>
                                         <Badge variant="outline" className="capitalize">
                                           {item.status}
                                         </Badge>

--- a/webapp/src/components/chat/chat-session-list.tsx
+++ b/webapp/src/components/chat/chat-session-list.tsx
@@ -17,7 +17,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { assignmentCategoryLabel, formatDateTime } from "@/lib/chat-utils"
+import { assignmentCategoryLabel, assignmentCategoryTone, formatDateTime } from "@/lib/chat-utils"
 import { type ChatSessionStatus } from "@/lib/chat-types"
 
 const EASE_OUT = [0.22, 1, 0.36, 1] as const
@@ -440,6 +440,7 @@ export function ChatSessionList() {
                                   ? item.last_user_message.trim()
                                   : "Chat Session"
                               const categoryLabel = assignmentCategoryLabel(item.assignment_category)
+                              const categoryTone = assignmentCategoryTone(item.assignment_category)
                               const isDeleting = deletingSessionIds.has(item.session_id)
 
                               return (
@@ -478,7 +479,7 @@ export function ChatSessionList() {
                                           {categoryLabel ? (
                                             <Badge
                                               variant="outline"
-                                              className="shrink-0 border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-200"
+                                              className={`shrink-0 px-2 py-0.5 text-[10px] ${categoryTone}`}
                                             >
                                               {categoryLabel}
                                             </Badge>

--- a/webapp/src/lib/chat-repository.ts
+++ b/webapp/src/lib/chat-repository.ts
@@ -69,6 +69,7 @@ type DbChatSession = {
   user_id: string;
   assignment_uuid: string;
   title?: string | null;
+  assignment_category?: string | null;
   status: ChatSessionStatus;
   created_at: string;
   updated_at: string;
@@ -359,6 +360,7 @@ export type UserChatSessionListItem = {
   sessionId: string;
   assignmentUuid: string;
   title: string;
+  assignmentCategory: string | null;
   lastUserMessage: string | null;
   status: ChatSessionStatus;
   createdAt: number;
@@ -398,6 +400,21 @@ function normalizePayload(payload: AssignmentPayload): AssignmentPayload {
     courseName: toOptionalString(payload.courseName) ?? undefined,
     source: normalizeSource(payload.source),
   };
+}
+
+function normalizeAssignmentCategory(value: string | null | undefined) {
+  const category = toOptionalString(value)?.toLowerCase() ?? null;
+  if (
+    category === "coding" ||
+    category === "mathematics" ||
+    category === "science" ||
+    category === "speech" ||
+    category === "essay" ||
+    category === "general"
+  ) {
+    return category;
+  }
+  return null;
 }
 
 async function upsertSingle<T>(input: {
@@ -1013,7 +1030,7 @@ async function getPersistedSessionSnapshotWithMessageLimit(
     table: "chat_sessions",
     query: {
       id: eq(sessionId),
-      select: "id,user_id,assignment_uuid,status,created_at,updated_at",
+      select: "id,user_id,assignment_uuid,assignment_category,status,created_at,updated_at",
       limit: 1,
     },
   });
@@ -1087,6 +1104,7 @@ async function getPersistedSessionSnapshotWithMessageLimit(
     createdAt: toEpoch(session.created_at),
     updatedAt: toEpoch(session.updated_at),
     status: session.status,
+    assignmentCategory: normalizeAssignmentCategory(session.assignment_category),
     payload,
     messages: allMessages.map((row) => toMessageDto(row)),
     guideMarkdown,
@@ -1237,7 +1255,7 @@ export async function listPersistedChatSessionsForUser(
     table: "chat_sessions",
     query: {
       user_id: eq(userId),
-      select: "id,user_id,assignment_uuid,title,status,created_at,updated_at",
+      select: "id,user_id,assignment_uuid,title,assignment_category,status,created_at,updated_at",
       order: "updated_at.desc",
       limit: boundedLimit,
     },
@@ -1349,6 +1367,7 @@ export async function listPersistedChatSessionsForUser(
         sessionId: session.id,
         assignmentUuid: session.assignment_uuid,
         title: toOptionalString(session.title) ?? assignmentTitle,
+        assignmentCategory: normalizeAssignmentCategory(session.assignment_category),
         lastUserMessage: lastUserMessageBySessionId.get(session.id) ?? null,
         status: session.status,
         createdAt,
@@ -1807,6 +1826,20 @@ export async function updateChatSessionStatus(
   });
 }
 
+export async function updateChatSessionCategory(sessionId: string, category: string) {
+  const normalized = normalizeAssignmentCategory(category) ?? "general";
+  return patchSingle<DbChatSession>({
+    table: "chat_sessions",
+    query: {
+      id: eq(sessionId),
+    },
+    patch: {
+      assignment_category: normalized,
+      updated_at: nowIso(),
+    },
+  });
+}
+
 async function getNextMessageIndex(sessionId: string) {
   const latest = await selectFirst<DbChatMessage>({
     table: "chat_messages",
@@ -1915,6 +1948,7 @@ export async function getSessionGuideAndHistory(sessionId: string) {
     userId: snapshot.userId,
     assignmentUuid: snapshot.assignmentUuid,
     assignmentRecordId: snapshot.assignmentRecordId ?? null,
+    assignmentCategory: snapshot.assignmentCategory,
   };
 }
 
@@ -1937,6 +1971,7 @@ export async function getSessionGuideAndRecentHistory(
     userId: snapshot.userId,
     assignmentUuid: snapshot.assignmentUuid,
     assignmentRecordId: snapshot.assignmentRecordId ?? null,
+    assignmentCategory: snapshot.assignmentCategory,
   };
 }
 

--- a/webapp/src/lib/chat-runtime-store.ts
+++ b/webapp/src/lib/chat-runtime-store.ts
@@ -146,7 +146,11 @@ export function markRuntimeFailed(sessionId: string, error: string) {
   });
 }
 
-export function markRuntimeCompleted(sessionId: string, guideMarkdown: string) {
+export function markRuntimeCompleted(
+  sessionId: string,
+  guideMarkdown: string,
+  assignmentCategory?: string | null,
+) {
   const current = ensureRuntimeSession(sessionId);
   return setRuntimeSession(sessionId, {
     ...current,
@@ -155,6 +159,7 @@ export function markRuntimeCompleted(sessionId: string, guideMarkdown: string) {
     progressPercent: 100,
     statusMessage: "Guide ready",
     streamedGuideMarkdown: guideMarkdown || current.streamedGuideMarkdown,
+    assignmentCategory: assignmentCategory ?? current.assignmentCategory ?? null,
     result: {
       guideMarkdown: guideMarkdown || current.streamedGuideMarkdown,
     },

--- a/webapp/src/lib/chat-session-runner.ts
+++ b/webapp/src/lib/chat-session-runner.ts
@@ -17,6 +17,7 @@ import {
   insertGuideVersion,
   listSignedSnapshotPdfFiles,
   persistSnapshotFileExtractions,
+  updateChatSessionCategory,
   updateChatMessageContent,
   updateChatSessionStatus,
 } from "@/lib/chat-repository";
@@ -170,6 +171,7 @@ function toStage(value: unknown) {
     value === "calling_agent" ||
     value === "streaming_output" ||
     value === "validating_output" ||
+    value === "classifying_assignment" ||
     value === "parsing_response" ||
     value === "completed" ||
     value === "failed" ||
@@ -373,9 +375,16 @@ async function runInitialGuide(input: {
           throw new Error("Agent returned empty guide markdown");
         }
 
+        const assignmentCategory = toOptionalString(data.assignment_category);
+        if (assignmentCategory) {
+          updateChatSessionCategory(sessionId, assignmentCategory).catch((err: unknown) => {
+            console.error("[chat-runner] Failed to persist assignment category:", err);
+          });
+        }
+
         await updateChatSessionStatus(sessionId, "completed");
 
-        markRuntimeCompleted(sessionId, guideMarkdown);
+        markRuntimeCompleted(sessionId, guideMarkdown, assignmentCategory ?? null);
 
         // Persist v1 — best-effort; don't fail the whole run if this errors
         insertGuideVersion({
@@ -669,6 +678,7 @@ async function runFollowupChat(input: {
       agentUrl,
       JSON.stringify({
         assignment_payload: assignmentPayload,
+        assignment_category: sessionContext.assignmentCategory ?? "",
         assignment_pdf_extractions: storedAssignmentPdfExtractions,
         assignment_pdf_text: pdfIsLong ? "" : pdfText,
         guide_markdown: sessionContext.guideMarkdown,
@@ -966,6 +976,7 @@ async function runGuideRegeneration(input: {
       agentUrl,
       JSON.stringify({
         assignment_payload: assignmentPayload,
+        assignment_category: sessionContext.assignmentCategory ?? "",
         guide_markdown: sessionContext.guideMarkdown,
         chat_history: chatHistory,
         retrieval_context: retrievalContext,

--- a/webapp/src/lib/chat-types.ts
+++ b/webapp/src/lib/chat-types.ts
@@ -89,6 +89,7 @@ export type ChatSessionStage =
   | "calling_agent"
   | "streaming_output"
   | "validating_output"
+  | "classifying_assignment"
   | "parsing_response"
   | "chat_streaming"
   | "completed"
@@ -119,6 +120,7 @@ export type ChatSessionDto = {
   progress_percent: number;
   status_message: string;
   streamed_guide_markdown: string;
+  assignment_category: string | null;
   result: unknown | null;
   error: string | null;
   payload: AssignmentPayload;
@@ -140,6 +142,7 @@ export type PersistedSessionSnapshot = {
   createdAt: number;
   updatedAt: number;
   status: ChatSessionStatus;
+  assignmentCategory: string | null;
   payload: AssignmentPayload;
   messages: ChatMessageDto[];
   guideMarkdown: string;
@@ -152,6 +155,7 @@ export type RuntimeSessionState = {
   progressPercent: number;
   statusMessage: string;
   streamedGuideMarkdown: string;
+  assignmentCategory?: string | null;
   result?: unknown;
   error?: string;
   updatedAt: number;
@@ -165,6 +169,7 @@ export function buildSessionDto(
   const stage = runtime?.stage ?? (status === "completed" ? "completed" : "queued");
   const streamedGuideMarkdown =
     runtime?.streamedGuideMarkdown || snapshot.guideMarkdown || "";
+  const assignmentCategory = runtime?.assignmentCategory ?? snapshot.assignmentCategory ?? null;
 
   let progress = runtime?.progressPercent;
   if (progress == null) {
@@ -199,6 +204,7 @@ export function buildSessionDto(
     progress_percent: Math.max(0, Math.min(100, Math.round(progress))),
     status_message: statusMessage,
     streamed_guide_markdown: streamedGuideMarkdown,
+    assignment_category: assignmentCategory,
     result,
     error,
     payload: snapshot.payload,

--- a/webapp/src/lib/chat-utils.ts
+++ b/webapp/src/lib/chat-utils.ts
@@ -91,6 +91,8 @@ export function stageLabel(stage: ChatSessionStage) {
       return "Streaming Output"
     case "validating_output":
       return "Validating Output"
+    case "classifying_assignment":
+      return "Classifying assignment"
     case "parsing_response":
       return "Parsing Response"
     case "chat_streaming":
@@ -109,4 +111,23 @@ export function formatDateTime(value: number | string | null | undefined) {
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return null
   return format(date, "MMM d, yyyy h:mm a")
+}
+
+export function assignmentCategoryLabel(value: string | null | undefined) {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "coding":
+      return "Coding"
+    case "mathematics":
+      return "Mathematics"
+    case "science":
+      return "Science"
+    case "speech":
+      return "Speech"
+    case "essay":
+      return "Essay"
+    case "general":
+      return "General"
+    default:
+      return null
+  }
 }

--- a/webapp/src/lib/chat-utils.ts
+++ b/webapp/src/lib/chat-utils.ts
@@ -131,3 +131,22 @@ export function assignmentCategoryLabel(value: string | null | undefined) {
       return null
   }
 }
+
+export function assignmentCategoryTone(value: string | null | undefined) {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "coding":
+      return "border-sky-500/35 bg-sky-500/10 text-sky-700 dark:text-sky-200"
+    case "mathematics":
+      return "border-violet-500/35 bg-violet-500/10 text-violet-700 dark:text-violet-200"
+    case "science":
+      return "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+    case "speech":
+      return "border-amber-500/35 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+    case "essay":
+      return "border-rose-500/35 bg-rose-500/10 text-rose-700 dark:text-rose-200"
+    case "general":
+      return "border-slate-500/35 bg-slate-500/10 text-slate-700 dark:text-slate-200"
+    default:
+      return "border-border/60 bg-muted/40 text-muted-foreground"
+  }
+}


### PR DESCRIPTION
This pull request implements LLM-based assignment category classification and threads the detected category through the agent service, webapp, and database, enabling category-specific chat guidance and UI labels. The classification step is performed after context extraction and before guide generation, with the result persisted as metadata and used to tailor follow-up chat system prompts. The design is fail-open: classification errors default to a generic category, ensuring backward compatibility and resilience.

**Key changes:**

### Agent Service: Assignment Classification and Prompting

- Added a new `classification_service.py` that uses NVIDIA GPT-OSS 120B to classify assignments into one of several categories (`coding`, `mathematics`, `science`, `speech`, `essay`, or `general`), defaulting to `general` on errors or unrecognized output. The classifier is invoked after context extraction and before guide generation, and its result is included in the `run.completed` payload. [[1]](diffhunk://#diff-8ecf345ac0497977285f15feb38fe69eda8b4dae6ff9252eb6630c0f589cc098R1-R203) [[2]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R12) [[3]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R88-R89) [[4]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R103-R104) [[5]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R129)
- Updated the orchestrator to append a category-specific system prompt addendum to follow-up chat prompts, based on the classified assignment category. The base prompt remains unchanged for `general` or unknown categories. [[1]](diffhunk://#diff-97c3d50fed04e2a174f82ea3dfaf6d5bc2045ef10e478211b598173c9e5d0bf9L952-R1021) [[2]](diffhunk://#diff-97c3d50fed04e2a174f82ea3dfaf6d5bc2045ef10e478211b598173c9e5d0bf9R1030) [[3]](diffhunk://#diff-97c3d50fed04e2a174f82ea3dfaf6d5bc2045ef10e478211b598173c9e5d0bf9L993-R1060)
- Extended the `ChatStreamRequest` schema to accept an optional `assignment_category` field, ensuring compatibility with older clients.

### Webapp and Database: Persistence and UI

- Updated the database schema (Supabase migration) to store the assignment category as nullable metadata on chat sessions, with a bounded set of allowed values and backward compatibility for old sessions.
- Modified webapp types, persistence logic, and UI to store, retrieve, and display the assignment category next to chat session headers and chat names in the chat list. The category is never shown in assistant responses.

### Documentation and Testing

- Updated architecture documentation to describe the new classification and prompt flow, including error handling and streaming behavior. [[1]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R12) [[2]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R88-R89) [[3]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R103-R104) [[4]](diffhunk://#diff-4ae1339bee7c22d667a3aea80ddd4586d763674adf47966640ad332d3572c908R129)
- Added and updated unit tests for the classifier, prompt selection, and run workflow to ensure correct category handling and robust fallback behavior.

These changes together enable a more tailored and context-aware chat experience for users, while maintaining reliability and compatibility across the system.