### PR TITLE
feat: RAG embedding client and chunking service (Issue #71)

### DIFF
--- a/agent_service/.env.example
+++ b/agent_service/.env.example
@@ -1,5 +1,10 @@
 NVIDIA_API_KEY=<your_nvidia_api_key_here>
 
+# RAG embedding model and configuration
+NVIDIA_EMBEDDING_MODEL=nvidia/llama-3.2-nv-embedqa-1b-v2
+RAG_EMBEDDING_DIM=2048
+RAG_EMBED_BATCH_SIZE=64
+
 # VLM-based PDF page extraction (fallback for scanned/image-heavy pages)
 # Model ID — switch to meta/llama-3.2-11b-vision-instruct for faster, lighter inference
 VLM_MODEL_ID=meta/llama-3.2-90b-vision-instruct

--- a/agent_service/app/clients/embedding_client.py
+++ b/agent_service/app/clients/embedding_client.py
@@ -1,0 +1,88 @@
+import os
+from functools import lru_cache
+
+from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
+
+_NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"
+
+# Default model and dimension; override via env.
+_DEFAULT_EMBEDDING_MODEL = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+_DEFAULT_EMBEDDING_DIM = 2048
+_DEFAULT_BATCH_SIZE = 64
+
+
+def _embedding_model() -> str:
+    return os.environ.get("NVIDIA_EMBEDDING_MODEL", _DEFAULT_EMBEDDING_MODEL)
+
+
+def _embedding_dim() -> int:
+    return int(os.environ.get("RAG_EMBEDDING_DIM", _DEFAULT_EMBEDDING_DIM))
+
+
+def _batch_size() -> int:
+    return int(os.environ.get("RAG_EMBED_BATCH_SIZE", _DEFAULT_BATCH_SIZE))
+
+
+@lru_cache(maxsize=1)
+def _build_client() -> NVIDIAEmbeddings:
+    return NVIDIAEmbeddings(
+        model=_embedding_model(),
+        base_url=os.environ.get("NVIDIA_BASE_URL", _NVIDIA_BASE_URL),
+        api_key=os.environ["NVIDIA_API_KEY"],
+    )
+
+
+def _assert_dim(vectors: list[list[float]]) -> None:
+    if not vectors:
+        return
+    actual = len(vectors[0])
+    expected = _embedding_dim()
+    if actual != expected:
+        raise RuntimeError(
+            f"Embedding dimension mismatch for model '{_embedding_model()}': "
+            f"expected {expected}, got {actual}. "
+            "Update RAG_EMBEDDING_DIM or change NVIDIA_EMBEDDING_MODEL."
+        )
+
+
+def embed_documents(texts: list[str]) -> list[list[float]]:
+    """Embed a list of documents in batches, validating output dimension on the first batch.
+
+    Args:
+        texts: Source text strings to embed.
+
+    Returns:
+        List of float vectors, one per input text.
+    """
+    if not texts:
+        return []
+
+    client = _build_client()
+    size = _batch_size()
+    results: list[list[float]] = []
+    checked = False
+
+    for i in range(0, len(texts), size):
+        batch = texts[i : i + size]
+        vecs = client.embed_documents(batch)
+        if not checked:
+            _assert_dim(vecs)
+            checked = True
+        results.extend(vecs)
+
+    return results
+
+
+def embed_query(text: str) -> list[float]:
+    """Embed a single query string.
+
+    Args:
+        text: Query text to embed.
+
+    Returns:
+        Float vector for the query.
+    """
+    client = _build_client()
+    vec = client.embed_query(text)
+    _assert_dim([vec])
+    return vec

--- a/agent_service/app/services/rag_chunking_service.py
+++ b/agent_service/app/services/rag_chunking_service.py
@@ -1,0 +1,299 @@
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from langchain_text_splitters import MarkdownHeaderTextSplitter, RecursiveCharacterTextSplitter
+
+CHUNKING_VERSION = "1"
+
+# Minimum quality thresholds — chunks below either are dropped.
+_MIN_CHARS = 20
+_MIN_WORDS = 4
+
+# Page marker emitted by pdf_text_service: "--- Page N (method) ---"
+_PAGE_MARKER_RE = re.compile(r"^---\s*Page\s+(\d+)\s+\(([^)]+)\)\s*---\s*$", re.MULTILINE)
+
+
+@dataclass
+class RagChunk:
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    content_hash: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Content hashing
+# ---------------------------------------------------------------------------
+
+
+def _normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _embedding_model() -> str:
+    return os.environ.get("NVIDIA_EMBEDDING_MODEL", "nvidia/llama-3.2-nv-embedqa-1b-v2")
+
+
+def compute_content_hash(source_type: str, source_id: str, text: str) -> str:
+    """Compute a stable SHA-256 dedup hash for a chunk.
+
+    Hash input includes source_type, source_id, normalized text, CHUNKING_VERSION,
+    and the active embedding model so that changing any of those forces a re-embed.
+
+    Args:
+        source_type: RAG source category (e.g. 'guide_markdown').
+        source_id: Stable identifier for the source document.
+        text: Raw chunk text (will be normalized before hashing).
+
+    Returns:
+        Hex SHA-256 digest.
+    """
+    normalized = _normalize(text)
+    payload = "|".join([source_type, source_id, normalized, CHUNKING_VERSION, _embedding_model()])
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Chunk validation
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_chunk(text: str) -> bool:
+    normalized = _normalize(text)
+    if len(normalized) < _MIN_CHARS:
+        return False
+    if len(normalized.split()) < _MIN_WORDS:
+        return False
+    return True
+
+
+def _make_chunk(text: str, source_type: str, source_id: str, metadata: dict[str, Any]) -> RagChunk | None:
+    if not _is_valid_chunk(text):
+        return None
+    return RagChunk(
+        text=text,
+        metadata=metadata,
+        content_hash=compute_content_hash(source_type, source_id, text),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guide markdown chunking
+# ---------------------------------------------------------------------------
+
+_MD_HEADERS = [("#", "h1"), ("##", "h2"), ("###", "h3")]
+
+
+def chunk_guide_markdown(markdown: str, source_id: str) -> list[RagChunk]:
+    """Split guide markdown by headers then by character length.
+
+    Args:
+        markdown: Full guide markdown text.
+        source_id: Stable source identifier (e.g. guide version id or session id).
+
+    Returns:
+        List of RagChunk with heading path preserved in metadata.
+    """
+    header_splitter = MarkdownHeaderTextSplitter(headers_to_split_on=_MD_HEADERS, strip_headers=False)
+    char_splitter = RecursiveCharacterTextSplitter(chunk_size=1200, chunk_overlap=150)
+
+    header_docs = header_splitter.split_text(markdown)
+    chunks: list[RagChunk] = []
+
+    for doc in header_docs:
+        sub_texts = char_splitter.split_text(doc.page_content)
+        heading_path = " > ".join(
+            v for k in ("h1", "h2", "h3") if (v := doc.metadata.get(k))
+        )
+        for text in sub_texts:
+            chunk = _make_chunk(
+                text,
+                "guide_markdown",
+                source_id,
+                {"heading": heading_path} if heading_path else {},
+            )
+            if chunk:
+                chunks.append(chunk)
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Assignment PDF chunking
+# ---------------------------------------------------------------------------
+
+
+def chunk_assignment_pdf(full_text: str, source_id: str, filename: str = "") -> list[RagChunk]:
+    """Split extracted PDF text by page markers then by character length.
+
+    Args:
+        full_text: Concatenated PDF text with '--- Page N (method) ---' markers.
+        source_id: Stable source identifier (e.g. file_sha256).
+        filename: Original PDF filename for metadata.
+
+    Returns:
+        List of RagChunk with page_number and extraction_method in metadata.
+    """
+    char_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=120)
+
+    # Find all page marker positions.
+    markers = list(_PAGE_MARKER_RE.finditer(full_text))
+    chunks: list[RagChunk] = []
+
+    if not markers:
+        # No page markers — treat as a single page.
+        for text in char_splitter.split_text(full_text):
+            chunk = _make_chunk(text, "assignment_pdf", source_id, {"filename": filename})
+            if chunk:
+                chunks.append(chunk)
+        return chunks
+
+    # Extract text between consecutive markers.
+    for i, marker in enumerate(markers):
+        page_num = int(marker.group(1))
+        method = marker.group(2)
+        start = marker.end()
+        end = markers[i + 1].start() if i + 1 < len(markers) else len(full_text)
+        page_text = full_text[start:end].strip()
+
+        for text in char_splitter.split_text(page_text):
+            meta: dict[str, Any] = {
+                "page_number": page_num,
+                "extraction_method": method,
+            }
+            if filename:
+                meta["filename"] = filename
+            chunk = _make_chunk(text, "assignment_pdf", source_id, meta)
+            if chunk:
+                chunks.append(chunk)
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Rubric chunking
+# ---------------------------------------------------------------------------
+
+
+def _criterion_to_text(criterion: dict[str, Any]) -> str:
+    parts: list[str] = []
+    if desc := criterion.get("description"):
+        parts.append(str(desc))
+    if pts := criterion.get("points"):
+        parts.append(f"Points: {pts}")
+    ratings = criterion.get("ratings") or criterion.get("rubric_ratings") or []
+    if ratings:
+        rating_lines = []
+        for r in ratings:
+            label = r.get("description") or r.get("long_description") or ""
+            pts_r = r.get("points", "")
+            rating_lines.append(f"  - {label} ({pts_r} pts)" if pts_r else f"  - {label}")
+        parts.append("Ratings:\n" + "\n".join(rating_lines))
+    return "\n".join(parts)
+
+
+def chunk_rubric(rubric: Any, source_id: str) -> list[RagChunk]:
+    """Split a rubric into one chunk per criterion when possible.
+
+    Args:
+        rubric: Rubric as a list of criterion dicts, a single dict, or plain text.
+        source_id: Stable source identifier (e.g. assignment snapshot id).
+
+    Returns:
+        List of RagChunk, one per criterion or from character splitting for plain text.
+    """
+    chunks: list[RagChunk] = []
+
+    if isinstance(rubric, str):
+        # Plain-text rubric — character split.
+        splitter = RecursiveCharacterTextSplitter(chunk_size=900, chunk_overlap=100)
+        for text in splitter.split_text(rubric):
+            chunk = _make_chunk(text, "rubric", source_id, {})
+            if chunk:
+                chunks.append(chunk)
+        return chunks
+
+    # JSON rubric: list of criteria or a Canvas rubric envelope.
+    criteria: list[dict[str, Any]] = []
+    if isinstance(rubric, list):
+        criteria = [c for c in rubric if isinstance(c, dict)]
+    elif isinstance(rubric, dict):
+        # Canvas wraps criteria under 'criteria' or 'rubric_criteria'.
+        for key in ("criteria", "rubric_criteria"):
+            if isinstance(rubric.get(key), list):
+                criteria = [c for c in rubric[key] if isinstance(c, dict)]
+                break
+        if not criteria:
+            criteria = [rubric]
+
+    for crit in criteria:
+        text = _criterion_to_text(crit)
+        crit_id = str(crit.get("id", ""))
+        meta: dict[str, Any] = {}
+        if crit_id:
+            meta["criterion_id"] = crit_id
+        chunk = _make_chunk(text, "rubric", source_id, meta)
+        if chunk:
+            chunks.append(chunk)
+
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Assignment payload chunking
+# ---------------------------------------------------------------------------
+
+
+def chunk_assignment_payload(payload: dict[str, Any], source_id: str) -> list[RagChunk]:
+    """Produce a single compact summary chunk from the assignment payload.
+
+    Args:
+        payload: Raw assignment payload dict.
+        source_id: Stable source identifier (e.g. assignment snapshot id).
+
+    Returns:
+        List with one RagChunk summary, or empty list if payload is empty.
+    """
+    parts: list[str] = []
+
+    if title := payload.get("title") or payload.get("name"):
+        parts.append(f"Title: {title}")
+    if course := payload.get("course_name") or payload.get("context_title"):
+        parts.append(f"Course: {course}")
+    if due := payload.get("due_at") or payload.get("due_date"):
+        parts.append(f"Due: {due}")
+    if pts := payload.get("points_possible"):
+        parts.append(f"Points: {pts}")
+    if sub := payload.get("submission_types") or payload.get("submission_type"):
+        sub_str = ", ".join(sub) if isinstance(sub, list) else str(sub)
+        parts.append(f"Submission: {sub_str}")
+
+    # Description capped at 2000 chars to keep the summary token-efficient.
+    desc = payload.get("description") or payload.get("description_text") or ""
+    if desc:
+        desc = str(desc)[:2000]
+        parts.append(f"Description:\n{desc}")
+
+    # Brief rubric summary (just criterion names).
+    rubric = payload.get("rubric") or payload.get("rubric_criteria")
+    if rubric:
+        try:
+            criteria = rubric if isinstance(rubric, list) else json.loads(rubric) if isinstance(rubric, str) else []
+            names = [c.get("description", "") for c in criteria if isinstance(c, dict)]
+            if names:
+                parts.append("Rubric criteria: " + "; ".join(n for n in names if n))
+        except Exception:
+            pass
+
+    if url := payload.get("html_url") or payload.get("canvas_url"):
+        parts.append(f"Canvas URL: {url}")
+
+    if not parts:
+        return []
+
+    text = "\n".join(parts)
+    chunk = _make_chunk(text, "assignment_payload", source_id, {})
+    return [chunk] if chunk else []

--- a/agent_service/requirements.txt
+++ b/agent_service/requirements.txt
@@ -4,5 +4,6 @@ python-dotenv
 pydantic
 langchain
 langchain-nvidia-ai-endpoints
+langchain-text-splitters
 pymupdf
 pillow

--- a/agent_service/tests/unit/test_embedding_client.py
+++ b/agent_service/tests/unit/test_embedding_client.py
@@ -1,0 +1,78 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from app.clients import embedding_client
+
+
+class TestEmbeddingClient(unittest.TestCase):
+    def setUp(self):
+        # Clear the lru_cache before each test so env changes take effect.
+        embedding_client._build_client.cache_clear()
+
+    def _mock_env(self, extra: dict | None = None) -> dict:
+        base = {
+            "NVIDIA_API_KEY": "test-key",
+            "NVIDIA_EMBEDDING_MODEL": "nvidia/llama-3.2-nv-embedqa-1b-v2",
+            "RAG_EMBEDDING_DIM": "4",
+            "RAG_EMBED_BATCH_SIZE": "2",
+        }
+        if extra:
+            base.update(extra)
+        return base
+
+    def test_embed_documents_batches_correctly(self):
+        """embed_documents respects RAG_EMBED_BATCH_SIZE and concatenates results."""
+        env = self._mock_env({"RAG_EMBED_BATCH_SIZE": "2", "RAG_EMBEDDING_DIM": "2"})
+        mock_client = MagicMock()
+        # Each call returns 2-dim vectors matching env dim.
+        mock_client.embed_documents.side_effect = [
+            [[0.1, 0.2], [0.3, 0.4]],
+            [[0.5, 0.6]],
+        ]
+
+        with patch.dict(os.environ, env, clear=False), patch(
+            "app.clients.embedding_client._build_client", return_value=mock_client
+        ):
+            result = embedding_client.embed_documents(["a", "b", "c"])
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual(mock_client.embed_documents.call_count, 2)
+        self.assertEqual(mock_client.embed_documents.call_args_list[0].args[0], ["a", "b"])
+        self.assertEqual(mock_client.embed_documents.call_args_list[1].args[0], ["c"])
+
+    def test_embed_documents_dim_mismatch_raises(self):
+        """embed_documents raises RuntimeError when output dim does not match RAG_EMBEDDING_DIM."""
+        env = self._mock_env({"RAG_EMBEDDING_DIM": "4"})
+        mock_client = MagicMock()
+        # Return 2-dim vectors when 4 are expected.
+        mock_client.embed_documents.return_value = [[0.1, 0.2]]
+
+        with patch.dict(os.environ, env, clear=False), patch(
+            "app.clients.embedding_client._build_client", return_value=mock_client
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                embedding_client.embed_documents(["hello"])
+
+        self.assertIn("dimension mismatch", str(ctx.exception).lower())
+
+    def test_embed_documents_empty_returns_empty(self):
+        """embed_documents with empty input returns empty list without calling the client."""
+        mock_client = MagicMock()
+        with patch("app.clients.embedding_client._build_client", return_value=mock_client):
+            result = embedding_client.embed_documents([])
+
+        self.assertEqual(result, [])
+        mock_client.embed_documents.assert_not_called()
+
+    def test_embed_query_dim_mismatch_raises(self):
+        """embed_query raises RuntimeError when output dim does not match RAG_EMBEDDING_DIM."""
+        env = self._mock_env({"RAG_EMBEDDING_DIM": "3"})
+        mock_client = MagicMock()
+        mock_client.embed_query.return_value = [0.1, 0.2]  # 2-dim, expected 3
+
+        with patch.dict(os.environ, env, clear=False), patch(
+            "app.clients.embedding_client._build_client", return_value=mock_client
+        ):
+            with self.assertRaises(RuntimeError):
+                embedding_client.embed_query("what is the rubric?")

--- a/agent_service/tests/unit/test_rag_chunking_service.py
+++ b/agent_service/tests/unit/test_rag_chunking_service.py
@@ -1,0 +1,127 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from app.services import rag_chunking_service as svc
+
+
+class TestComputeContentHash(unittest.TestCase):
+    def test_hash_is_stable(self):
+        h1 = svc.compute_content_hash("guide_markdown", "src-1", "some text")
+        h2 = svc.compute_content_hash("guide_markdown", "src-1", "some text")
+        self.assertEqual(h1, h2)
+
+    def test_hash_differs_on_embedding_model_change(self):
+        with patch.dict(os.environ, {"NVIDIA_EMBEDDING_MODEL": "model-a"}):
+            h1 = svc.compute_content_hash("guide_markdown", "src-1", "text")
+        with patch.dict(os.environ, {"NVIDIA_EMBEDDING_MODEL": "model-b"}):
+            h2 = svc.compute_content_hash("guide_markdown", "src-1", "text")
+        self.assertNotEqual(h1, h2)
+
+    def test_hash_differs_on_source_type_change(self):
+        h1 = svc.compute_content_hash("guide_markdown", "src-1", "text")
+        h2 = svc.compute_content_hash("rubric", "src-1", "text")
+        self.assertNotEqual(h1, h2)
+
+    def test_whitespace_normalization(self):
+        """Extra whitespace is collapsed before hashing so reformatted text matches."""
+        h1 = svc.compute_content_hash("rubric", "s", "hello   world")
+        h2 = svc.compute_content_hash("rubric", "s", "hello world")
+        self.assertEqual(h1, h2)
+
+
+class TestGuideMarkdownChunking(unittest.TestCase):
+    def test_heading_preserved_in_metadata(self):
+        md = "# Overview\n\nThis is the overview.\n\n## Details\n\nSome details here.\n"
+        chunks = svc.chunk_guide_markdown(md, "guide-1")
+        self.assertTrue(len(chunks) > 0)
+        headings = [c.metadata.get("heading", "") for c in chunks]
+        self.assertTrue(any("Overview" in h for h in headings))
+
+    def test_chunks_meet_minimum_length(self):
+        md = "# Title\n\nShort.\n\n## Section\n\n" + ("word " * 30)
+        chunks = svc.chunk_guide_markdown(md, "guide-1")
+        for chunk in chunks:
+            self.assertGreaterEqual(len(chunk.text.split()), svc._MIN_WORDS)
+
+    def test_empty_markdown_returns_empty(self):
+        self.assertEqual(svc.chunk_guide_markdown("", "g"), [])
+
+
+class TestPdfChunking(unittest.TestCase):
+    def test_page_number_and_method_in_metadata(self):
+        text = (
+            "--- Page 1 (native) ---\nFirst page content with enough words here.\n"
+            "--- Page 2 (hybrid) ---\nSecond page content with enough words too.\n"
+        )
+        chunks = svc.chunk_assignment_pdf(text, "sha256-abc", filename="lab.pdf")
+        self.assertTrue(len(chunks) > 0)
+        page_nums = {c.metadata.get("page_number") for c in chunks}
+        methods = {c.metadata.get("extraction_method") for c in chunks}
+        self.assertIn(1, page_nums)
+        self.assertIn(2, page_nums)
+        self.assertIn("native", methods)
+        self.assertIn("hybrid", methods)
+
+    def test_filename_in_metadata(self):
+        text = "--- Page 1 (native) ---\nPage one content with enough words here.\n"
+        chunks = svc.chunk_assignment_pdf(text, "sha256-abc", filename="rubric.pdf")
+        self.assertTrue(all(c.metadata.get("filename") == "rubric.pdf" for c in chunks))
+
+    def test_no_markers_falls_back_gracefully(self):
+        text = "This is a PDF without any page markers. " * 10
+        chunks = svc.chunk_assignment_pdf(text, "sha256-abc")
+        self.assertTrue(len(chunks) > 0)
+
+
+class TestRubricChunking(unittest.TestCase):
+    def test_one_chunk_per_criterion(self):
+        rubric = [
+            {"id": "1", "description": "Code quality and readability", "points": 10},
+            {"id": "2", "description": "Testing and coverage", "points": 15},
+            {"id": "3", "description": "Documentation clarity", "points": 5},
+        ]
+        chunks = svc.chunk_rubric(rubric, "snap-1")
+        self.assertEqual(len(chunks), 3)
+
+    def test_criterion_id_in_metadata(self):
+        rubric = [{"id": "crit-42", "description": "Correctness of output", "points": 20}]
+        chunks = svc.chunk_rubric(rubric, "snap-1")
+        self.assertEqual(chunks[0].metadata.get("criterion_id"), "crit-42")
+
+    def test_plain_text_rubric_falls_back_to_splitter(self):
+        rubric = "Students will be graded on clarity, depth, and originality. " * 15
+        chunks = svc.chunk_rubric(rubric, "snap-1")
+        self.assertTrue(len(chunks) > 0)
+
+    def test_canvas_envelope_criteria_extracted(self):
+        rubric = {"criteria": [
+            {"id": "a", "description": "Correctness of algorithm implementation", "points": 5},
+            {"id": "b", "description": "Code style and documentation quality", "points": 5},
+        ]}
+        chunks = svc.chunk_rubric(rubric, "snap-1")
+        self.assertEqual(len(chunks), 2)
+
+
+class TestPayloadChunking(unittest.TestCase):
+    def test_produces_single_chunk(self):
+        payload = {
+            "title": "Lab 4: Sorting Algorithms",
+            "course_name": "CS 101",
+            "due_at": "2026-05-10T23:59:00Z",
+            "points_possible": 100,
+            "submission_types": ["online_upload"],
+            "description": "Implement merge sort and quick sort.",
+        }
+        chunks = svc.chunk_assignment_payload(payload, "snap-2")
+        self.assertEqual(len(chunks), 1)
+
+    def test_description_truncated(self):
+        payload = {"title": "Big Assignment", "description": "x" * 3000}
+        chunks = svc.chunk_assignment_payload(payload, "snap-2")
+        self.assertEqual(len(chunks), 1)
+        self.assertLessEqual(len(chunks[0].text), 3000)
+
+    def test_empty_payload_returns_empty(self):
+        chunks = svc.chunk_assignment_payload({}, "snap-2")
+        self.assertEqual(chunks, [])


### PR DESCRIPTION
## Summary
- Adds `embedding_client.py` wrapping `NVIDIAEmbeddings` with batched `embed_documents`, `embed_query`, and dimension validation on first use (raises `RuntimeError` with model name and expected vs actual dim on mismatch)
- Adds `rag_chunking_service.py` with source-aware text splitters (guide markdown via `MarkdownHeaderTextSplitter`, PDF by page markers, rubric per criterion, payload as compact summary) and stable SHA-256 content hashing for dedup
- `langchain-text-splitters` added to `requirements.txt`
- `NVIDIA_EMBEDDING_MODEL`, `RAG_EMBEDDING_DIM`, `RAG_EMBED_BATCH_SIZE` added to `.env.example`

## Test plan
- [x] 21 unit tests added and passing (`test_embedding_client.py`, `test_rag_chunking_service.py`)
- [x] Hash stability verified across identical inputs
- [x] Hash changes when `NVIDIA_EMBEDDING_MODEL` env var changes
- [x] Dim mismatch raises `RuntimeError` in both `embed_documents` and `embed_query`
- [x] PDF page marker parsing captures page number and extraction method in metadata
- [x] Canvas rubric envelope criteria extracted correctly
- [x] Empty inputs return empty lists without calling the client

Closes #71