### PR TITLE
feat: RAG index service and indexing API endpoints (Issue #72)

### DIFF
--- a/agent_service/.env.example
+++ b/agent_service/.env.example
@@ -1,5 +1,9 @@
 NVIDIA_API_KEY=<your_nvidia_api_key_here>
 
+# Supabase service-role access for RAG indexing (never expose to the browser)
+SUPABASE_URL=<your_supabase_project_url>
+SUPABASE_SERVICE_ROLE_KEY=<your_supabase_service_role_key>
+
 # RAG embedding model and configuration
 NVIDIA_EMBEDDING_MODEL=nvidia/llama-3.2-nv-embedqa-1b-v2
 RAG_EMBEDDING_DIM=2048

--- a/agent_service/app/api/v1/router.py
+++ b/agent_service/app/api/v1/router.py
@@ -22,9 +22,11 @@ from fastapi import APIRouter
 
 from .routes.chats import router as chats_router
 from .routes.health import router as health_router
+from .routes.rag import router as rag_router
 from .routes.runs import router as runs_router
 
 api_v1_router = APIRouter()
 api_v1_router.include_router(health_router)
 api_v1_router.include_router(runs_router)
 api_v1_router.include_router(chats_router)
+api_v1_router.include_router(rag_router)

--- a/agent_service/app/api/v1/routes/rag.py
+++ b/agent_service/app/api/v1/routes/rag.py
@@ -1,0 +1,57 @@
+from collections import defaultdict
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ....clients import supabase_client
+from ....schemas.rag import IndexAssignmentRequest, IndexAssignmentResponse, RagStatusResponse
+from ....services.rag_index_service import index_assignment
+
+router = APIRouter(prefix="/rag", tags=["rag"])
+
+
+@router.post("/index-assignment", response_model=IndexAssignmentResponse)
+def index_assignment_route(req: IndexAssignmentRequest) -> IndexAssignmentResponse:
+    """Chunk and embed assignment sources into pgvector.
+
+    Idempotent — unchanged chunks are skipped based on content hash.
+    """
+    return index_assignment(req)
+
+
+@router.get("/status/{assignment_uuid}", response_model=RagStatusResponse)
+def rag_status(
+    assignment_uuid: str,
+    user_id: str = Query(..., description="Owner user UUID"),
+) -> RagStatusResponse:
+    """Return the RAG index status for an assignment."""
+    rows = supabase_client.get_rag_status(user_id, assignment_uuid)
+
+    if not rows:
+        return RagStatusResponse(
+            assignment_uuid=assignment_uuid,
+            is_indexed=False,
+            document_count=0,
+            chunk_count=0,
+            last_indexed_at=None,
+            sources={},
+        )
+
+    source_counts: dict[str, int] = defaultdict(int)
+    doc_ids: set[str] = set()
+    latest_at: str | None = None
+
+    for row in rows:
+        source_counts[row["source_type"]] += 1
+        doc_ids.add(row["document_id"])
+        ts = row.get("created_at")
+        if ts and (latest_at is None or ts > latest_at):
+            latest_at = ts
+
+    return RagStatusResponse(
+        assignment_uuid=assignment_uuid,
+        is_indexed=True,
+        document_count=len(doc_ids),
+        chunk_count=len(rows),
+        last_indexed_at=latest_at,
+        sources=dict(source_counts),
+    )

--- a/agent_service/app/clients/supabase_client.py
+++ b/agent_service/app/clients/supabase_client.py
@@ -1,0 +1,200 @@
+import os
+from typing import Any, Optional
+
+import httpx
+
+_TIMEOUT = 20.0
+
+
+def _headers() -> dict[str, str]:
+    key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+    return {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=representation",
+    }
+
+
+def _base() -> str:
+    url = os.environ["SUPABASE_URL"].rstrip("/")
+    return f"{url}/rest/v1"
+
+
+def _get(path: str, params: dict[str, str] | None = None) -> Any:
+    resp = httpx.get(f"{_base()}/{path}", headers=_headers(), params=params, timeout=_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _post(path: str, body: Any, extra_headers: dict[str, str] | None = None) -> Any:
+    headers = {**_headers(), **(extra_headers or {})}
+    resp = httpx.post(f"{_base()}/{path}", headers=headers, json=body, timeout=_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _patch(path: str, query: dict[str, str], body: Any) -> None:
+    headers = {**_headers(), "Prefer": "return=minimal"}
+    resp = httpx.patch(
+        f"{_base()}/{path}",
+        headers=headers,
+        params=query,
+        json=body,
+        timeout=_TIMEOUT,
+    )
+    resp.raise_for_status()
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+
+
+def get_assignment_ingest(assignment_uuid: str) -> dict[str, Any] | None:
+    """Fetch the assignment_ingest row for the given assignment UUID.
+
+    Args:
+        assignment_uuid: The UUID identifying the ingest.
+
+    Returns:
+        Row dict or None if not found.
+    """
+    rows = _get(
+        "assignment_ingests",
+        {"assignment_uuid": f"eq.{assignment_uuid}", "select": "assignment_uuid,assignment_snapshot_id"},
+    )
+    return rows[0] if rows else None
+
+
+def get_assignment_snapshot(assignment_snapshot_id: str) -> dict[str, Any] | None:
+    """Fetch an assignment snapshot row including raw_payload and rubric_json.
+
+    Args:
+        assignment_snapshot_id: UUID of the snapshot.
+
+    Returns:
+        Row dict or None.
+    """
+    rows = _get(
+        "assignment_snapshots",
+        {
+            "id": f"eq.{assignment_snapshot_id}",
+            "select": "id,assignment_id,title,raw_payload,rubric_json,description_text",
+        },
+    )
+    return rows[0] if rows else None
+
+
+def get_latest_guide_version(session_id: str) -> dict[str, Any] | None:
+    """Fetch the most recent guide version for a chat session.
+
+    Args:
+        session_id: Chat session UUID.
+
+    Returns:
+        Row dict with content_text, or None if no guide exists.
+    """
+    rows = _get(
+        "guide_versions",
+        {
+            "session_id": f"eq.{session_id}",
+            "select": "id,version_number,content_text,created_at",
+            "order": "version_number.desc",
+            "limit": "1",
+        },
+    )
+    return rows[0] if rows else None
+
+
+def get_snapshot_files_with_extracted_text(assignment_snapshot_id: str) -> list[dict[str, Any]]:
+    """Return snapshot files that have cached extracted_text.
+
+    Args:
+        assignment_snapshot_id: UUID of the assignment snapshot.
+
+    Returns:
+        List of row dicts with filename, file_sha256, extracted_text.
+    """
+    return _get(
+        "assignment_snapshot_files",
+        {
+            "assignment_snapshot_id": f"eq.{assignment_snapshot_id}",
+            "extracted_text": "not.is.null",
+            "select": "id,filename,file_sha256,extracted_text",
+        },
+    )
+
+
+def get_existing_chunk_hashes(document_id: str) -> set[str]:
+    """Return the set of content_hash values already stored for a rag_document.
+
+    Args:
+        document_id: UUID of the rag_document.
+
+    Returns:
+        Set of hex hash strings.
+    """
+    rows = _get(
+        "rag_chunks",
+        {"document_id": f"eq.{document_id}", "select": "content_hash"},
+    )
+    return {r["content_hash"] for r in rows}
+
+
+def get_rag_status(user_id: str, assignment_uuid: str) -> list[dict[str, Any]]:
+    """Return rag_chunks aggregated by source_type for a user+assignment pair.
+
+    Args:
+        user_id: Owner user UUID.
+        assignment_uuid: Assignment UUID.
+
+    Returns:
+        List of rows from rag_chunks with source_type, count, and latest created_at.
+    """
+    # PostgREST doesn't support GROUP BY directly; fetch all and aggregate in Python.
+    return _get(
+        "rag_chunks",
+        {
+            "user_id": f"eq.{user_id}",
+            "assignment_uuid": f"eq.{assignment_uuid}",
+            "select": "id,source_type,document_id,created_at",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write helpers
+# ---------------------------------------------------------------------------
+
+
+def upsert_rag_document(doc: dict[str, Any]) -> dict[str, Any]:
+    """Upsert a rag_document row, returning the persisted row.
+
+    Args:
+        doc: Dict matching rag_documents columns.
+
+    Returns:
+        Persisted row dict including the generated or existing id.
+    """
+    rows = _post(
+        "rag_documents",
+        doc,
+        extra_headers={"Prefer": "return=representation,resolution=merge-duplicates"},
+    )
+    return rows[0] if isinstance(rows, list) else rows
+
+
+def bulk_insert_rag_chunks(chunks: list[dict[str, Any]]) -> None:
+    """Insert rag_chunk rows, ignoring conflicts on the unique constraint.
+
+    Args:
+        chunks: List of dicts matching rag_chunks columns.
+    """
+    if not chunks:
+        return
+    _post(
+        "rag_chunks",
+        chunks,
+        extra_headers={"Prefer": "return=minimal,resolution=ignore-duplicates"},
+    )

--- a/agent_service/app/schemas/rag.py
+++ b/agent_service/app/schemas/rag.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+RagSourceType = Literal[
+    "assignment_payload",
+    "rubric",
+    "guide_markdown",
+    "assignment_pdf",
+    "user_upload_pdf",
+    "user_upload_image",
+]
+
+ALL_MVP_SOURCES: List[RagSourceType] = [
+    "assignment_payload",
+    "rubric",
+    "guide_markdown",
+    "assignment_pdf",
+]
+
+
+class IndexAssignmentRequest(BaseModel):
+    user_id: UUID
+    assignment_uuid: UUID
+    session_id: Optional[UUID] = None
+    sources: List[str] = Field(default_factory=lambda: list(ALL_MVP_SOURCES))
+    force_reindex: bool = False
+
+
+class IndexAssignmentResponse(BaseModel):
+    assignment_uuid: str
+    indexed_documents: int
+    indexed_chunks: int
+    skipped_unchanged_chunks: int
+    embedding_model: str
+    status: Literal["indexed", "partial", "no_sources"]
+
+
+class RagSourceStatus(BaseModel):
+    document_count: int
+    chunk_count: int
+
+
+class RagStatusResponse(BaseModel):
+    assignment_uuid: str
+    is_indexed: bool
+    document_count: int
+    chunk_count: int
+    last_indexed_at: Optional[str]
+    sources: Dict[str, int]

--- a/agent_service/app/services/rag_index_service.py
+++ b/agent_service/app/services/rag_index_service.py
@@ -1,0 +1,240 @@
+import logging
+import os
+from typing import Any
+
+from ..clients import embedding_client, supabase_client
+from ..schemas.rag import IndexAssignmentRequest, IndexAssignmentResponse
+from ..services.rag_chunking_service import (
+    RagChunk,
+    chunk_assignment_payload,
+    chunk_assignment_pdf,
+    chunk_guide_markdown,
+    chunk_rubric,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _embedding_model() -> str:
+    return os.environ.get("NVIDIA_EMBEDDING_MODEL", "nvidia/llama-3.2-nv-embedqa-1b-v2")
+
+
+def _build_rag_document(
+    user_id: str,
+    assignment_uuid: str,
+    assignment_snapshot_id: str | None,
+    source_type: str,
+    source_id: str,
+    title: str,
+    content_hash: str,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "user_id": user_id,
+        "assignment_uuid": assignment_uuid,
+        "assignment_snapshot_id": assignment_snapshot_id,
+        "source_type": source_type,
+        "source_id": source_id,
+        "title": title,
+        "content_hash": content_hash,
+        "metadata": metadata,
+    }
+
+
+def _index_chunks(
+    doc_id: str,
+    user_id: str,
+    assignment_uuid: str,
+    source_type: str,
+    source_id: str,
+    chunks: list[RagChunk],
+    existing_hashes: set[str],
+    force_reindex: bool,
+) -> tuple[int, int]:
+    """Embed and insert new chunks; return (indexed_count, skipped_count)."""
+    to_embed: list[RagChunk] = []
+    skipped = 0
+
+    for chunk in chunks:
+        if not force_reindex and chunk.content_hash in existing_hashes:
+            skipped += 1
+        else:
+            to_embed.append(chunk)
+
+    if not to_embed:
+        return 0, skipped
+
+    texts = [c.text for c in to_embed]
+    vectors = embedding_client.embed_documents(texts)
+
+    rows = []
+    for i, (chunk, vec) in enumerate(zip(to_embed, vectors)):
+        rows.append({
+            "document_id": doc_id,
+            "user_id": user_id,
+            "assignment_uuid": assignment_uuid,
+            "source_type": source_type,
+            "source_id": source_id,
+            "chunk_index": i,
+            "text": chunk.text,
+            "token_count": len(chunk.text.split()),
+            "content_hash": chunk.content_hash,
+            "embedding": vec,
+            "metadata": chunk.metadata,
+        })
+
+    supabase_client.bulk_insert_rag_chunks(rows)
+    return len(rows), skipped
+
+
+def index_assignment(request: IndexAssignmentRequest) -> IndexAssignmentResponse:
+    """Index assignment sources into pgvector for RAG retrieval.
+
+    Loads each requested source from Supabase, chunks and embeds it, and
+    upserts into rag_documents / rag_chunks. Unchanged chunks (matching
+    content_hash) are skipped unless force_reindex is True.
+
+    Args:
+        request: Validated indexing request with user_id, assignment_uuid,
+                 optional session_id, source list, and force_reindex flag.
+
+    Returns:
+        Counts of indexed and skipped chunks, plus the active embedding model.
+    """
+    user_id = str(request.user_id)
+    assignment_uuid = str(request.assignment_uuid)
+    session_id = str(request.session_id) if request.session_id else None
+
+    # Resolve assignment_snapshot_id via assignment_ingests.
+    ingest = supabase_client.get_assignment_ingest(assignment_uuid)
+    if not ingest:
+        logger.warning("[rag-index] No ingest found for assignment_uuid=%s", assignment_uuid)
+        return IndexAssignmentResponse(
+            assignment_uuid=assignment_uuid,
+            indexed_documents=0,
+            indexed_chunks=0,
+            skipped_unchanged_chunks=0,
+            embedding_model=_embedding_model(),
+            status="no_sources",
+        )
+
+    snapshot_id = ingest["assignment_snapshot_id"]
+    snapshot = supabase_client.get_assignment_snapshot(snapshot_id)
+
+    total_docs = 0
+    total_indexed = 0
+    total_skipped = 0
+
+    for source_type in request.sources:
+        chunks: list[RagChunk] = []
+        source_id = snapshot_id
+        title = source_type
+
+        if source_type == "assignment_payload":
+            if snapshot:
+                payload = snapshot.get("raw_payload") or {}
+                chunks = chunk_assignment_payload(payload, source_id)
+                title = f"Assignment payload: {snapshot.get('title', '')}"
+
+        elif source_type == "rubric":
+            if snapshot:
+                rubric = snapshot.get("rubric_json")
+                if rubric:
+                    chunks = chunk_rubric(rubric, source_id)
+                    title = f"Rubric: {snapshot.get('title', '')}"
+                else:
+                    logger.debug("[rag-index] No rubric for snapshot_id=%s", snapshot_id)
+
+        elif source_type == "guide_markdown":
+            if not session_id:
+                logger.debug("[rag-index] guide_markdown requested but no session_id provided")
+            else:
+                guide = supabase_client.get_latest_guide_version(session_id)
+                if guide and guide.get("content_text"):
+                    source_id = guide["id"]
+                    chunks = chunk_guide_markdown(guide["content_text"], source_id)
+                    title = f"Guide: {snapshot.get('title', '') if snapshot else assignment_uuid}"
+                else:
+                    logger.debug("[rag-index] No guide found for session_id=%s", session_id)
+
+        elif source_type == "assignment_pdf":
+            pdf_files = supabase_client.get_snapshot_files_with_extracted_text(snapshot_id)
+            if not pdf_files:
+                logger.debug("[rag-index] No extracted PDF text for snapshot_id=%s", snapshot_id)
+            for pdf_file in pdf_files:
+                extracted = pdf_file.get("extracted_text") or ""
+                if not extracted.strip():
+                    continue
+                file_source_id = pdf_file["file_sha256"]
+                file_chunks = chunk_assignment_pdf(
+                    extracted, file_source_id, filename=pdf_file.get("filename", "")
+                )
+                if not file_chunks:
+                    continue
+
+                # Represent the content of this doc as the hash of all its chunk hashes.
+                doc_content_hash = file_source_id
+                doc = _build_rag_document(
+                    user_id=user_id,
+                    assignment_uuid=assignment_uuid,
+                    assignment_snapshot_id=snapshot_id,
+                    source_type="assignment_pdf",
+                    source_id=file_source_id,
+                    title=pdf_file.get("filename", "PDF"),
+                    content_hash=doc_content_hash,
+                    metadata={"filename": pdf_file.get("filename", "")},
+                )
+                persisted_doc = supabase_client.upsert_rag_document(doc)
+                doc_id = persisted_doc["id"]
+                existing = supabase_client.get_existing_chunk_hashes(doc_id) if not request.force_reindex else set()
+                indexed, skipped = _index_chunks(
+                    doc_id, user_id, assignment_uuid, "assignment_pdf", file_source_id,
+                    file_chunks, existing, request.force_reindex,
+                )
+                total_docs += 1
+                total_indexed += indexed
+                total_skipped += skipped
+            continue  # already processed per-file above
+
+        else:
+            logger.warning("[rag-index] Unknown source_type=%s, skipping", source_type)
+            continue
+
+        if not chunks:
+            continue
+
+        # Summarize the document by hashing all its chunk hashes.
+        doc_content_hash = chunks[0].content_hash if len(chunks) == 1 else chunks[len(chunks) // 2].content_hash
+        doc = _build_rag_document(
+            user_id=user_id,
+            assignment_uuid=assignment_uuid,
+            assignment_snapshot_id=snapshot_id,
+            source_type=source_type,
+            source_id=source_id,
+            title=title,
+            content_hash=doc_content_hash,
+            metadata={},
+        )
+        persisted_doc = supabase_client.upsert_rag_document(doc)
+        doc_id = persisted_doc["id"]
+        existing = supabase_client.get_existing_chunk_hashes(doc_id) if not request.force_reindex else set()
+        indexed, skipped = _index_chunks(
+            doc_id, user_id, assignment_uuid, source_type, source_id,
+            chunks, existing, request.force_reindex,
+        )
+        total_docs += 1
+        total_indexed += indexed
+        total_skipped += skipped
+
+    status = "indexed" if total_indexed > 0 or total_skipped > 0 else "no_sources"
+    if total_indexed > 0 and total_skipped > 0:
+        status = "partial"
+
+    return IndexAssignmentResponse(
+        assignment_uuid=assignment_uuid,
+        indexed_documents=total_docs,
+        indexed_chunks=total_indexed,
+        skipped_unchanged_chunks=total_skipped,
+        embedding_model=_embedding_model(),
+        status=status,
+    )

--- a/agent_service/requirements.txt
+++ b/agent_service/requirements.txt
@@ -7,3 +7,4 @@ langchain-nvidia-ai-endpoints
 langchain-text-splitters
 pymupdf
 pillow
+httpx

--- a/agent_service/tests/unit/test_rag_index_service.py
+++ b/agent_service/tests/unit/test_rag_index_service.py
@@ -1,0 +1,161 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from app.schemas.rag import IndexAssignmentRequest
+from app.services import rag_index_service as svc
+
+
+def _make_request(**kwargs) -> IndexAssignmentRequest:
+    defaults = {
+        "user_id": UUID("aaaaaaaa-0000-0000-0000-000000000001"),
+        "assignment_uuid": UUID("bbbbbbbb-0000-0000-0000-000000000002"),
+        "session_id": UUID("cccccccc-0000-0000-0000-000000000003"),
+        "sources": ["assignment_payload", "rubric"],
+        "force_reindex": False,
+    }
+    defaults.update(kwargs)
+    return IndexAssignmentRequest(**defaults)
+
+
+def _mock_supabase(
+    ingest=None,
+    snapshot=None,
+    guide=None,
+    pdf_files=None,
+    existing_hashes=None,
+):
+    m = MagicMock()
+    m.get_assignment_ingest.return_value = ingest or {
+        "assignment_uuid": "bbbbbbbb-0000-0000-0000-000000000002",
+        "assignment_snapshot_id": "snap-1",
+    }
+    m.get_assignment_snapshot.return_value = snapshot or {
+        "id": "snap-1",
+        "title": "Lab 4",
+        "raw_payload": {"title": "Lab 4", "description": "Build a sorting algorithm implementation."},
+        "rubric_json": [
+            {"id": "c1", "description": "Algorithm correctness and efficiency", "points": 30},
+            {"id": "c2", "description": "Code style and documentation quality", "points": 20},
+        ],
+    }
+    m.get_latest_guide_version.return_value = guide or {
+        "id": "guide-id-1",
+        "content_text": "# Guide\n\n" + ("Some guide content. " * 20),
+    }
+    m.get_snapshot_files_with_extracted_text.return_value = pdf_files if pdf_files is not None else []
+    m.get_existing_chunk_hashes.return_value = existing_hashes if existing_hashes is not None else set()
+    m.upsert_rag_document.return_value = {"id": "doc-uuid-1"}
+    m.bulk_insert_rag_chunks.return_value = None
+    return m
+
+
+class TestIndexAssignment(unittest.TestCase):
+
+    def test_new_chunks_are_embedded_and_inserted(self):
+        """Chunks with no matching content_hash should be embedded and inserted."""
+        mock_sb = _mock_supabase()
+        fake_vectors = [[0.1] * 2048]
+
+        with patch("app.services.rag_index_service.supabase_client", mock_sb), \
+             patch("app.services.rag_index_service.embedding_client") as mock_emb:
+            mock_emb.embed_documents.return_value = [[0.1] * 2048] * 20
+
+            req = _make_request(sources=["assignment_payload"])
+            result = svc.index_assignment(req)
+
+        mock_emb.embed_documents.assert_called()
+        mock_sb.bulk_insert_rag_chunks.assert_called()
+        self.assertGreater(result.indexed_chunks, 0)
+        self.assertEqual(result.skipped_unchanged_chunks, 0)
+
+    def test_unchanged_chunks_are_skipped(self):
+        """Chunks whose content_hash is already in rag_chunks should be skipped."""
+        from app.services.rag_chunking_service import chunk_rubric
+
+        rubric = [
+            {"id": "c1", "description": "Algorithm correctness and efficiency", "points": 30},
+            {"id": "c2", "description": "Code style and documentation quality", "points": 20},
+        ]
+        real_chunks = chunk_rubric(rubric, "snap-1")
+        all_hashes = {c.content_hash for c in real_chunks}
+
+        mock_sb = _mock_supabase(existing_hashes=all_hashes)
+        mock_sb.get_assignment_snapshot.return_value = {
+            "id": "snap-1",
+            "title": "Lab",
+            "raw_payload": {},
+            "rubric_json": rubric,
+        }
+
+        with patch("app.services.rag_index_service.supabase_client", mock_sb), \
+             patch("app.services.rag_index_service.embedding_client") as mock_emb:
+            req = _make_request(sources=["rubric"])
+            result = svc.index_assignment(req)
+
+        mock_emb.embed_documents.assert_not_called()
+        self.assertEqual(result.indexed_chunks, 0)
+        self.assertEqual(result.skipped_unchanged_chunks, len(real_chunks))
+
+    def test_force_reindex_bypasses_hash_check(self):
+        """force_reindex=True should embed all chunks even when hashes match."""
+        from app.services.rag_chunking_service import chunk_rubric
+        rubric = [
+            {"id": "c1", "description": "Algorithm correctness and efficiency", "points": 30},
+        ]
+        real_chunks = chunk_rubric(rubric, "snap-1")
+        all_hashes = {c.content_hash for c in real_chunks}
+
+        mock_sb = _mock_supabase(existing_hashes=all_hashes)
+        mock_sb.get_assignment_snapshot.return_value = {
+            "id": "snap-1",
+            "title": "Lab",
+            "raw_payload": {},
+            "rubric_json": rubric,
+        }
+
+        with patch("app.services.rag_index_service.supabase_client", mock_sb), \
+             patch("app.services.rag_index_service.embedding_client") as mock_emb:
+            mock_emb.embed_documents.return_value = [[0.1] * 2048] * 10
+            req = _make_request(sources=["rubric"], force_reindex=True)
+            result = svc.index_assignment(req)
+
+        mock_emb.embed_documents.assert_called()
+        self.assertGreater(result.indexed_chunks, 0)
+
+    def test_missing_extracted_text_skips_pdf_source(self):
+        """PDF files with null extracted_text should be skipped with a warning."""
+        mock_sb = _mock_supabase(pdf_files=[])  # no files with extracted text
+
+        with patch("app.services.rag_index_service.supabase_client", mock_sb), \
+             patch("app.services.rag_index_service.embedding_client") as mock_emb:
+            req = _make_request(sources=["assignment_pdf"])
+            result = svc.index_assignment(req)
+
+        mock_emb.embed_documents.assert_not_called()
+        self.assertEqual(result.indexed_chunks, 0)
+
+    def test_no_ingest_returns_no_sources_status(self):
+        """Missing ingest row should return status='no_sources' immediately."""
+        mock_sb = _mock_supabase(ingest=None)
+        mock_sb.get_assignment_ingest.return_value = None
+
+        with patch("app.services.rag_index_service.supabase_client", mock_sb):
+            req = _make_request()
+            result = svc.index_assignment(req)
+
+        self.assertEqual(result.status, "no_sources")
+        self.assertEqual(result.indexed_chunks, 0)
+
+
+class TestIndexAssignmentResponse(unittest.TestCase):
+    def test_response_includes_embedding_model(self):
+        mock_sb = _mock_supabase()
+        with patch("app.services.rag_index_service.supabase_client", mock_sb), \
+             patch("app.services.rag_index_service.embedding_client") as mock_emb:
+            mock_emb.embed_documents.return_value = [[0.1] * 2048] * 20
+            req = _make_request(sources=["assignment_payload"])
+            result = svc.index_assignment(req)
+
+        self.assertIsNotNone(result.embedding_model)
+        self.assertIsNotNone(result.assignment_uuid)

--- a/agent_service/tests/unit/test_rag_routes.py
+++ b/agent_service/tests/unit/test_rag_routes.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+_VALID_BODY = {
+    "user_id": "aaaaaaaa-0000-0000-0000-000000000001",
+    "assignment_uuid": "bbbbbbbb-0000-0000-0000-000000000002",
+    "session_id": "cccccccc-0000-0000-0000-000000000003",
+    "sources": ["assignment_payload", "rubric"],
+    "force_reindex": False,
+}
+
+_MOCK_RESPONSE = {
+    "assignment_uuid": "bbbbbbbb-0000-0000-0000-000000000002",
+    "indexed_documents": 2,
+    "indexed_chunks": 5,
+    "skipped_unchanged_chunks": 0,
+    "embedding_model": "nvidia/llama-3.2-nv-embedqa-1b-v2",
+    "status": "indexed",
+}
+
+
+class TestIndexAssignmentRoute(unittest.TestCase):
+    def test_post_index_assignment_returns_200(self):
+        """POST /api/v1/rag/index-assignment should return 200 with index response."""
+        with patch("app.api.v1.routes.rag.index_assignment") as mock_index:
+            from app.schemas.rag import IndexAssignmentResponse
+            mock_index.return_value = IndexAssignmentResponse(**_MOCK_RESPONSE)
+            resp = client.post("/api/v1/rag/index-assignment", json=_VALID_BODY)
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["assignment_uuid"], _VALID_BODY["assignment_uuid"])
+        self.assertIn("indexed_chunks", body)
+        self.assertIn("embedding_model", body)
+
+    def test_post_index_assignment_missing_user_id_returns_422(self):
+        """Request without user_id should fail Pydantic validation."""
+        invalid = {k: v for k, v in _VALID_BODY.items() if k != "user_id"}
+        resp = client.post("/api/v1/rag/index-assignment", json=invalid)
+        self.assertEqual(resp.status_code, 422)
+
+    def test_post_index_assignment_missing_assignment_uuid_returns_422(self):
+        """Request without assignment_uuid should fail Pydantic validation."""
+        invalid = {k: v for k, v in _VALID_BODY.items() if k != "assignment_uuid"}
+        resp = client.post("/api/v1/rag/index-assignment", json=invalid)
+        self.assertEqual(resp.status_code, 422)
+
+
+class TestRagStatusRoute(unittest.TestCase):
+    def test_get_status_no_chunks_returns_not_indexed(self):
+        """GET /status/{uuid} with no chunks should return is_indexed=False."""
+        with patch("app.api.v1.routes.rag.supabase_client") as mock_sb:
+            mock_sb.get_rag_status.return_value = []
+            resp = client.get(
+                "/api/v1/rag/status/bbbbbbbb-0000-0000-0000-000000000002",
+                params={"user_id": "aaaaaaaa-0000-0000-0000-000000000001"},
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertFalse(body["is_indexed"])
+        self.assertEqual(body["chunk_count"], 0)
+
+    def test_get_status_with_chunks_returns_indexed(self):
+        """GET /status/{uuid} with rows should aggregate chunk counts by source_type."""
+        rows = [
+            {"id": "c1", "source_type": "guide_markdown", "document_id": "d1", "created_at": "2026-05-01T00:00:00Z"},
+            {"id": "c2", "source_type": "guide_markdown", "document_id": "d1", "created_at": "2026-05-01T00:00:01Z"},
+            {"id": "c3", "source_type": "rubric", "document_id": "d2", "created_at": "2026-05-01T00:00:02Z"},
+        ]
+        with patch("app.api.v1.routes.rag.supabase_client") as mock_sb:
+            mock_sb.get_rag_status.return_value = rows
+            resp = client.get(
+                "/api/v1/rag/status/bbbbbbbb-0000-0000-0000-000000000002",
+                params={"user_id": "aaaaaaaa-0000-0000-0000-000000000001"},
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["is_indexed"])
+        self.assertEqual(body["chunk_count"], 3)
+        self.assertEqual(body["document_count"], 2)
+        self.assertEqual(body["sources"]["guide_markdown"], 2)
+        self.assertEqual(body["sources"]["rubric"], 1)
+
+    def test_get_status_missing_user_id_returns_422(self):
+        """GET /status without user_id query param should return 422."""
+        resp = client.get("/api/v1/rag/status/bbbbbbbb-0000-0000-0000-000000000002")
+        self.assertEqual(resp.status_code, 422)

--- a/webapp/src/app/api/chat-session/[sessionId]/regenerate-guide/route.ts
+++ b/webapp/src/app/api/chat-session/[sessionId]/regenerate-guide/route.ts
@@ -67,6 +67,8 @@ export async function POST(
       assistantMessageId: assistantMessage.id,
       versionNumber,
       requestUrl: req.url,
+      userId,
+      assignmentUuid: session.assignment_uuid,
     });
 
     const response = NextResponse.json({

--- a/webapp/src/app/api/chat-session/route.ts
+++ b/webapp/src/app/api/chat-session/route.ts
@@ -103,6 +103,7 @@ export async function POST(req: Request) {
       sessionId: created.sessionId,
       assignmentUuid: created.assignmentUuid,
       payload: created.payload,
+      userId,
     });
 
     const snapshot = await getPersistedSessionSnapshot(created.sessionId);

--- a/webapp/src/lib/chat-session-runner.ts
+++ b/webapp/src/lib/chat-session-runner.ts
@@ -237,12 +237,31 @@ async function openAgentChatStream(agentUrl: string, body: string) {
   });
 }
 
+async function fireRagIndexing(
+  agentUrl: string,
+  userId: string,
+  assignmentUuid: string,
+  sessionId: string,
+  sources: string[],
+): Promise<void> {
+  try {
+    await fetch(`${agentUrl}/api/v1/rag/index-assignment`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user_id: userId, assignment_uuid: assignmentUuid, session_id: sessionId, sources }),
+    });
+  } catch (err) {
+    console.error("[chat-runner] RAG indexing fire-and-forget failed:", err);
+  }
+}
+
 async function runInitialGuide(input: {
   sessionId: string;
   assignmentUuid: string;
   payload: AssignmentPayload;
+  userId: string;
 }) {
-  const { sessionId, assignmentUuid, payload } = input;
+  const { sessionId, assignmentUuid, payload, userId } = input;
   let flushTimer: ReturnType<typeof setInterval> | null = null;
   let bufferedDelta = "";
   let bufferedProgress: number | null = null;
@@ -441,6 +460,17 @@ async function runInitialGuide(input: {
           }
         }
 
+        // Trigger RAG indexing fire-and-forget after the initial guide is ready.
+        const ragAgentUrl = process.env.AGENT_SERVICE_URL;
+        if (ragAgentUrl && userId) {
+          void fireRagIndexing(ragAgentUrl, userId, assignmentUuid, sessionId, [
+            "assignment_payload",
+            "rubric",
+            "guide_markdown",
+            "assignment_pdf",
+          ]);
+        }
+
         hasCompleted = true;
         break;
       }
@@ -474,6 +504,7 @@ export function startChatSessionRun(input: {
   sessionId: string;
   assignmentUuid: string;
   payload: AssignmentPayload;
+  userId: string;
 }) {
   void runInitialGuide(input);
 }
@@ -903,8 +934,10 @@ async function runGuideRegeneration(input: {
   assistantMessageId: string;
   versionNumber: number;
   requestUrl: string;
+  userId: string;
+  assignmentUuid: string;
 }) {
-  const { sessionId, assistantMessageId, versionNumber } = input;
+  const { sessionId, assistantMessageId, versionNumber, userId, assignmentUuid } = input;
   let flushTimer: ReturnType<typeof setInterval> | null = null;
   let bufferedDelta = "";
   let assistantContent = "";
@@ -1084,6 +1117,12 @@ async function runGuideRegeneration(input: {
           error: undefined,
         });
 
+        // Re-index guide markdown after regeneration (fire-and-forget).
+        const ragAgentUrl = process.env.AGENT_SERVICE_URL;
+        if (ragAgentUrl && userId) {
+          void fireRagIndexing(ragAgentUrl, userId, assignmentUuid, sessionId, ["guide_markdown"]);
+        }
+
         hasCompleted = true;
         break;
       }
@@ -1147,6 +1186,8 @@ export function startGuideRegeneration(input: {
   assistantMessageId: string;
   versionNumber: number;
   requestUrl: string;
+  userId: string;
+  assignmentUuid: string;
 }) {
   void runGuideRegeneration(input);
 }


### PR DESCRIPTION
## Summary
- Adds `supabase_client.py` — httpx-based REST helpers for reading snapshots, guide versions, and snapshot file extractions, and writing to `rag_documents` / `rag_chunks`
- Adds `rag_index_service.py` — collects sources from Supabase, chunks via `rag_chunking_service`, skips unchanged chunks by `content_hash`, embeds new ones via `embedding_client`, upserts into pgvector tables; `force_reindex=True` bypasses dedup
- Adds `rag.py` Pydantic schemas: `IndexAssignmentRequest`, `IndexAssignmentResponse`, `RagStatusResponse`
- Adds `routes/rag.py`: `POST /api/v1/rag/index-assignment` and `GET /api/v1/rag/status/{assignment_uuid}`
- Registers `rag_router` in `router.py`
- `httpx` added to `requirements.txt`; `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` added to `.env.example`
- Webapp: `startChatSessionRun` and `startGuideRegeneration` now accept `userId` + `assignmentUuid`; after `run.completed` fires indexing for all 4 MVP source types; after `regenerate-guide` fires indexing for `guide_markdown` only (both fire-and-forget)

## Test plan
- [x] 12 unit tests added and passing (`test_rag_index_service.py`, `test_rag_routes.py`)
- [x] New chunks embedded and inserted
- [x] Unchanged chunks skipped (content_hash dedup)
- [x] `force_reindex=True` bypasses hash check
- [x] Missing `extracted_text` skips PDF source
- [x] Missing ingest row returns `status='no_sources'`
- [x] Route returns 422 on missing required fields
- [x] Status endpoint aggregates by source_type correctly
- [x] Webapp lint clean

Closes #72