### PR TITLE
RAG 5/8: retrieval service and hybrid chat integration

### DIFF
--- a/agent_service/app/clients/supabase_client.py
+++ b/agent_service/app/clients/supabase_client.py
@@ -31,6 +31,8 @@ def _post(path: str, body: Any, extra_headers: dict[str, str] | None = None) -> 
     headers = {**_headers(), **(extra_headers or {})}
     resp = httpx.post(f"{_base()}/{path}", headers=headers, json=body, timeout=_TIMEOUT)
     resp.raise_for_status()
+    if not resp.content:
+        return None
     return resp.json()
 
 
@@ -161,6 +163,41 @@ def get_rag_status(user_id: str, assignment_uuid: str) -> list[dict[str, Any]]:
             "select": "id,source_type,document_id,created_at",
         },
     )
+
+
+def match_rag_chunks(
+    query_embedding: list[float],
+    user_id: str,
+    assignment_uuid: str,
+    match_count: int = 12,
+    source_types: Optional[list[str]] = None,
+    session_id: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Call the match_rag_chunks RPC for scoped semantic retrieval.
+
+    Args:
+        query_embedding: Embedded query vector.
+        user_id: Owner user UUID used to scope retrieval.
+        assignment_uuid: Assignment UUID used to scope retrieval.
+        match_count: Maximum number of rows to return.
+        source_types: Optional source type filter.
+        session_id: Optional upload-session filter.
+
+    Returns:
+        List of matched chunk rows from PostgREST.
+    """
+    rows = _post(
+        "rpc/match_rag_chunks",
+        {
+            "query_embedding": query_embedding,
+            "match_user_id": user_id,
+            "match_assignment_uuid": assignment_uuid,
+            "match_count": match_count,
+            "source_types": source_types,
+            "match_session_id": session_id,
+        },
+    )
+    return rows if isinstance(rows, list) else []
 
 
 # ---------------------------------------------------------------------------

--- a/agent_service/app/orchestrators/headstart_orchestrator.py
+++ b/agent_service/app/orchestrators/headstart_orchestrator.py
@@ -708,6 +708,7 @@ calendar data is unavailable and suggest they open the Calendar Planner page.
 - In regenerated guides, prioritize student preferences and opinions over legacy guide phrasing.
 - Be concise and actionable; avoid padding or repeating context back to the student.
 - Use bullet lists, numbered steps, or short code snippets when they make an answer clearer.
+- When citing information from retrieved context, use the source label (for example [A] or [B]).
 - If relevant context is absent or ambiguous, explicitly say so.
 - End with a concrete next step whenever the student's question is task-oriented.\
 """
@@ -1039,6 +1040,7 @@ def stream_headstart_chat_answer(
     assignment_category: str = "",
     chat_history: Optional[list[dict]] = None,
     retrieval_context: Optional[list[dict]] = None,
+    retrieval_context_text: Optional[str] = None,
     user_message: str = "",
     include_thinking: bool = False,
     calendar_context: Optional[dict] = None,
@@ -1081,10 +1083,13 @@ def stream_headstart_chat_answer(
         _format_chat_history_for_prompt(chat_history),
         MAX_CHAT_HISTORY_CHARS,
     )
-    retrieval_context_str = _truncate_for_chat(
-        _format_retrieval_context_for_prompt(retrieval_context),
-        MAX_CHAT_RETRIEVAL_CHARS,
-    )
+    if retrieval_context_text is not None:
+        retrieval_context_str = _truncate_for_chat(retrieval_context_text, MAX_CHAT_RETRIEVAL_CHARS)
+    else:
+        retrieval_context_str = _truncate_for_chat(
+            _format_retrieval_context_for_prompt(retrieval_context),
+            MAX_CHAT_RETRIEVAL_CHARS,
+        )
     user_message_str = (user_message or "").strip()
     if not user_message_str:
         user_message_str = "Please summarize what I should do next."
@@ -1143,4 +1148,3 @@ def stream_headstart_chat_answer(
 
     if not yielded:
         raise RuntimeError("Model stream returned no follow-up response.")
-

--- a/agent_service/app/schemas/rag.py
+++ b/agent_service/app/schemas/rag.py
@@ -50,3 +50,14 @@ class RagStatusResponse(BaseModel):
     chunk_count: int
     last_indexed_at: Optional[str]
     sources: Dict[str, int]
+
+
+class RetrievedChunk(BaseModel):
+    chunk_id: UUID
+    document_id: UUID
+    source_type: RagSourceType
+    source_id: str
+    text: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    similarity: float = 0.0
+    label: Optional[str] = None

--- a/agent_service/app/schemas/requests.py
+++ b/agent_service/app/schemas/requests.py
@@ -20,9 +20,11 @@ Errors/Exceptions:
 """
 
 from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from .rag import RagSourceType
 from .shared import ImageFile, PdfExtraction, PdfFile
 
 
@@ -42,7 +44,7 @@ class ChatHistoryMessage(BaseModel):
 
 class RetrievalChunk(BaseModel):
     chunk_id: str
-    source: Literal["guide_markdown", "assignment_payload", "assignment_pdf"]
+    source: RagSourceType
     text: str
     score: float = 0.0
 
@@ -98,6 +100,11 @@ class ChatStreamRequest(BaseModel):
     guide_markdown: str = ""
     chat_history: List[ChatHistoryMessage] = Field(default_factory=list)
     retrieval_context: List[RetrievalChunk] = Field(default_factory=list)
+    user_id: Optional[UUID] = None
+    assignment_uuid: Optional[UUID] = None
+    retrieval_mode: Literal["semantic", "hybrid", "lexical"] = "hybrid"
+    retrieval_top_k: int = 12
+    source_types: Optional[List[RagSourceType]] = None
     user_message: str
     thinking_mode: bool = False
     calendar_context: Optional[CalendarContext] = None

--- a/agent_service/app/services/rag_context_formatter.py
+++ b/agent_service/app/services/rag_context_formatter.py
@@ -1,0 +1,125 @@
+import os
+import string
+from dataclasses import dataclass
+from typing import Sequence
+
+from ..schemas.rag import RetrievedChunk
+
+DEFAULT_CONTEXT_CHAR_BUDGET = 16000
+
+
+@dataclass(frozen=True)
+class FormattedRagContext:
+    text: str
+    sources: list[RetrievedChunk]
+
+
+def _context_budget() -> int:
+    return int(os.environ.get("RAG_CONTEXT_CHAR_BUDGET", DEFAULT_CONTEXT_CHAR_BUDGET))
+
+
+def _label_for_index(index: int) -> str:
+    alphabet = string.ascii_uppercase
+    label = ""
+    n = index
+    while True:
+        label = alphabet[n % len(alphabet)] + label
+        n = n // len(alphabet) - 1
+        if n < 0:
+            return label
+
+
+def _metadata_value(metadata: dict, *keys: str) -> str:
+    for key in keys:
+        value = metadata.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return ""
+
+
+def _quote(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _header_for_chunk(chunk: RetrievedChunk, label: str) -> str:
+    metadata = chunk.metadata or {}
+    parts = [label, chunk.source_type]
+
+    filename = _metadata_value(metadata, "filename", "file", "name")
+    if filename:
+        parts.append(f'file="{_quote(filename)}"')
+
+    page = _metadata_value(metadata, "page_number", "page")
+    if page:
+        parts.append(f"page={page}")
+
+    method = _metadata_value(metadata, "extraction_method", "method")
+    if method:
+        parts.append(f"method={method}")
+
+    heading = _metadata_value(metadata, "heading", "section", "title")
+    if heading:
+        parts.append(f'section="{_quote(heading)}"')
+
+    criterion_id = _metadata_value(metadata, "criterion_id")
+    if criterion_id:
+        parts.append(f'criterion="{_quote(criterion_id)}"')
+
+    return f"[{' | '.join(parts)}]"
+
+
+def _format_block(chunk: RetrievedChunk) -> str:
+    label = chunk.label or "?"
+    header = _header_for_chunk(chunk, label)
+    return f"{header}\n{chunk.text.strip()}\n"
+
+
+def _within_budget(blocks: list[str], budget: int) -> bool:
+    return len("\n".join(blocks)) <= budget
+
+
+def _trim_single_block(chunk: RetrievedChunk, budget: int) -> str:
+    header = _header_for_chunk(chunk, chunk.label or "?")
+    available = max(0, budget - len(header) - len("\n...[truncated]\n"))
+    text = chunk.text.strip()
+    if len(text) > available:
+        text = f"{text[:available]}\n...[truncated]"
+    return f"{header}\n{text}\n"
+
+
+def format_retrieved_context(
+    chunks: Sequence[RetrievedChunk],
+    char_budget: int | None = None,
+) -> FormattedRagContext:
+    """Format retrieved chunks as labeled context blocks within a character budget.
+
+    Args:
+        chunks: Retrieved chunks in preferred ranking order.
+        char_budget: Optional total character budget override.
+
+    Returns:
+        Formatted context text plus the labeled chunks that fit in the budget.
+    """
+    budget = char_budget if char_budget is not None else _context_budget()
+    labeled = [
+        chunk.model_copy(update={"label": _label_for_index(index)})
+        for index, chunk in enumerate(chunks)
+        if chunk.text.strip()
+    ]
+    if not labeled:
+        return FormattedRagContext(text="(none)", sources=[])
+
+    included = list(labeled)
+    while included:
+        blocks = [_format_block(chunk) for chunk in included]
+        if _within_budget(blocks, budget):
+            return FormattedRagContext(text="\n".join(blocks), sources=included)
+        if len(included) == 1:
+            return FormattedRagContext(
+                text=_trim_single_block(included[0], budget),
+                sources=included,
+            )
+        lowest = min(range(len(included)), key=lambda i: included[i].similarity)
+        included.pop(lowest)
+
+    return FormattedRagContext(text="(none)", sources=[])

--- a/agent_service/app/services/rag_retrieval_service.py
+++ b/agent_service/app/services/rag_retrieval_service.py
@@ -1,0 +1,122 @@
+import math
+import os
+from collections import defaultdict
+from typing import Sequence
+from uuid import UUID
+
+from ..clients import embedding_client, supabase_client
+from ..core.logging import get_logger
+from ..schemas.rag import RetrievedChunk
+
+logger = get_logger("headstart.rag_retrieval")
+
+DEFAULT_TOP_K = 12
+MMR_SIMILARITY_THRESHOLD = 0.92
+SOURCE_CAPS = {
+    "assignment_pdf": 6,
+    "guide_markdown": 4,
+    "rubric": 3,
+    "assignment_payload": 2,
+    "user_upload": 4,
+}
+
+
+def _mmr_threshold() -> float:
+    return float(os.environ.get("MMR_SIMILARITY_THRESHOLD", MMR_SIMILARITY_THRESHOLD))
+
+
+def _source_cap_key(source_type: str) -> str:
+    if source_type.startswith("user_upload"):
+        return "user_upload"
+    return source_type
+
+
+def _cap_by_source(chunks: Sequence[RetrievedChunk]) -> list[RetrievedChunk]:
+    counts: dict[str, int] = defaultdict(int)
+    selected: list[RetrievedChunk] = []
+    for chunk in chunks:
+        cap_key = _source_cap_key(chunk.source_type)
+        cap = SOURCE_CAPS.get(cap_key)
+        if cap is not None and counts[cap_key] >= cap:
+            continue
+        selected.append(chunk)
+        counts[cap_key] += 1
+    return selected
+
+
+def _cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    dot = sum(a * b for a, b in zip(left, right))
+    left_norm = math.sqrt(sum(a * a for a in left))
+    right_norm = math.sqrt(sum(b * b for b in right))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return dot / (left_norm * right_norm)
+
+
+def _remove_near_duplicates(chunks: list[RetrievedChunk]) -> list[RetrievedChunk]:
+    threshold = _mmr_threshold()
+    if len(chunks) < 2 or threshold <= 0 or threshold >= 1:
+        return chunks
+
+    try:
+        vectors = embedding_client.embed_documents([chunk.text for chunk in chunks])
+    except Exception:
+        logger.warning("RAG MMR duplicate filtering failed; returning capped chunks", exc_info=True)
+        return chunks
+    if len(vectors) != len(chunks):
+        logger.warning("RAG MMR vector count mismatch; returning capped chunks")
+        return chunks
+
+    selected_chunks: list[RetrievedChunk] = []
+    selected_vectors: list[list[float]] = []
+    for chunk, vector in zip(chunks, vectors):
+        duplicate = any(
+            _cosine_similarity(vector, selected_vector) > threshold
+            for selected_vector in selected_vectors
+        )
+        if duplicate:
+            continue
+        selected_chunks.append(chunk)
+        selected_vectors.append(vector)
+    return selected_chunks
+
+
+def retrieve(
+    query: str,
+    user_id: UUID,
+    assignment_uuid: UUID,
+    top_k: int = DEFAULT_TOP_K,
+    source_types: list[str] | None = None,
+) -> list[RetrievedChunk]:
+    """Retrieve semantically relevant chunks for a scoped assignment chat query.
+
+    Args:
+        query: User query to embed and search.
+        user_id: User UUID used to isolate RAG chunks.
+        assignment_uuid: Assignment UUID used to isolate RAG chunks.
+        top_k: Maximum number of chunks to return after caps and deduplication.
+        source_types: Optional source type filter.
+
+    Returns:
+        Ranked retrieved chunks, possibly empty when no index rows match.
+    """
+    normalized_query = (query or "").strip()
+    if not normalized_query:
+        return []
+
+    limit = max(1, top_k)
+    query_embedding = embedding_client.embed_query(normalized_query)
+    rows = supabase_client.match_rag_chunks(
+        query_embedding=query_embedding,
+        user_id=str(user_id),
+        assignment_uuid=str(assignment_uuid),
+        match_count=max(limit * 3, limit),
+        source_types=source_types,
+    )
+    if not rows:
+        return []
+
+    chunks = [RetrievedChunk.model_validate(row) for row in rows]
+    capped = _cap_by_source(chunks)
+    deduped = _remove_near_duplicates(capped)
+    return deduped[:limit]

--- a/agent_service/app/services/run_agent_service.py
+++ b/agent_service/app/services/run_agent_service.py
@@ -21,10 +21,13 @@ Errors/Exceptions:
 
 import math
 import json
+import uuid
+from difflib import SequenceMatcher
 from typing import Generator
 
 from ..core.logging import get_logger
 from ..schemas.requests import ChatStreamRequest, RunAgentRequest
+from ..schemas.rag import RetrievedChunk
 from ..schemas.responses import ChatCompletionResponse, RunAgentResponse
 from ..schemas.shared import PdfExtraction, PdfExtractionQuality, PdfPageExtraction
 from .image_extraction_service import extract_images_deduped
@@ -36,6 +39,8 @@ from .pdf_extraction_service import (
     format_pdf_extractions_for_prompt,
 )
 from .pdf_text_service import format_attachment_block
+from .rag_context_formatter import format_retrieved_context
+from .rag_retrieval_service import retrieve as retrieve_rag_chunks
 
 logger = get_logger("headstart.main")
 
@@ -63,7 +68,7 @@ def _stream_headstart_chat_answer(
     assignment_category: str,
     guide_markdown: str,
     chat_history: list[dict],
-    retrieval_context: list[dict],
+    retrieval_context_text: str,
     user_message: str,
     include_thinking: bool = False,
     calendar_context: dict | None = None,
@@ -78,7 +83,7 @@ def _stream_headstart_chat_answer(
         assignment_category=assignment_category,
         guide_markdown=guide_markdown,
         chat_history=chat_history,
-        retrieval_context=retrieval_context,
+        retrieval_context_text=retrieval_context_text,
         user_message=user_message,
         include_thinking=include_thinking,
         calendar_context=calendar_context,
@@ -362,6 +367,73 @@ def _extract_user_pdf_files_deduped(pdf_files: list) -> list:
     return extract_pdf_extractions_from_pdf_files(unique_files, source="user_upload")
 
 
+def _stable_uuid(seed: str) -> uuid.UUID:
+    return uuid.uuid5(uuid.NAMESPACE_URL, seed)
+
+
+def _legacy_chunk_to_retrieved(item: object) -> RetrievedChunk | None:
+    source = getattr(item, "source", None)
+    text = str(getattr(item, "text", "") or "").strip()
+    if not source or not text:
+        return None
+
+    raw_chunk_id = str(getattr(item, "chunk_id", "") or "")
+    try:
+        chunk_id = uuid.UUID(raw_chunk_id)
+    except ValueError:
+        chunk_id = _stable_uuid(f"legacy-rag-chunk:{source}:{raw_chunk_id}:{text[:160]}")
+
+    score = float(getattr(item, "score", 0.0) or 0.0)
+    return RetrievedChunk(
+        chunk_id=chunk_id,
+        document_id=_stable_uuid(f"legacy-rag-document:{source}:{raw_chunk_id}"),
+        source_type=source,
+        source_id=f"legacy:{raw_chunk_id or chunk_id}",
+        text=text,
+        metadata={"retrieval": "lexical", "legacy_chunk_id": raw_chunk_id},
+        similarity=score,
+    )
+
+
+def _text_similarity(left: str, right: str) -> float:
+    left_norm = " ".join(left.lower().split())
+    right_norm = " ".join(right.lower().split())
+    if not left_norm or not right_norm:
+        return 0.0
+    if left_norm == right_norm:
+        return 1.0
+    if left_norm in right_norm or right_norm in left_norm:
+        shorter = min(len(left_norm), len(right_norm))
+        longer = max(len(left_norm), len(right_norm))
+        return shorter / longer
+    return SequenceMatcher(None, left_norm, right_norm).ratio()
+
+
+def _merge_retrieval_chunks(
+    semantic_chunks: list[RetrievedChunk],
+    lexical_chunks: list[RetrievedChunk],
+) -> list[RetrievedChunk]:
+    selected = list(semantic_chunks)
+    for lexical in lexical_chunks:
+        if any(_text_similarity(lexical.text, selected_chunk.text) >= 0.88 for selected_chunk in selected):
+            continue
+        selected.append(lexical)
+    return selected
+
+
+def _build_legacy_retrieval_chunks(req: ChatStreamRequest) -> list[RetrievedChunk]:
+    chunks: list[RetrievedChunk] = []
+    for item in req.retrieval_context or []:
+        chunk = _legacy_chunk_to_retrieved(item)
+        if chunk:
+            chunks.append(chunk)
+    return chunks
+
+
+def _serialize_sources(chunks: list[RetrievedChunk]) -> list[dict]:
+    return [chunk.model_dump(mode="json") for chunk in chunks]
+
+
 def stream_chat_workflow(req: ChatStreamRequest, route_path: str) -> Generator[dict, None, None]:
     """
     Execute follow-up chat workflow and emit typed stream events for SSE clients.
@@ -460,6 +532,50 @@ def stream_chat_workflow(req: ChatStreamRequest, route_path: str) -> Generator[d
             len(assignment_extractions),
         )
 
+        lexical_chunks = _build_legacy_retrieval_chunks(req)
+        semantic_chunks: list[RetrievedChunk] = []
+        retrieval_warning: str | None = None
+        should_retrieve = (
+            req.retrieval_mode != "lexical"
+            and req.user_id is not None
+            and req.assignment_uuid is not None
+        )
+
+        if should_retrieve:
+            try:
+                semantic_chunks = retrieve_rag_chunks(
+                    query=req.user_message,
+                    user_id=req.user_id,
+                    assignment_uuid=req.assignment_uuid,
+                    top_k=req.retrieval_top_k,
+                    source_types=req.source_types,
+                )
+                if not semantic_chunks:
+                    retrieval_warning = "Semantic retrieval returned no chunks; using lexical context."
+            except Exception as retrieval_exc:
+                logger.warning("Semantic RAG retrieval failed; using lexical context", exc_info=True)
+                retrieval_warning = str(retrieval_exc)
+
+        if retrieval_warning:
+            yield _build_event(
+                "chat.retrieval_warning",
+                {
+                    "stage": "chat_streaming",
+                    "progress_percent": 97,
+                    "status_message": "Semantic retrieval unavailable; using fallback context",
+                    "message": retrieval_warning,
+                },
+            )
+
+        if semantic_chunks and req.retrieval_mode == "semantic":
+            retrieval_chunks = semantic_chunks
+        elif semantic_chunks and req.retrieval_mode == "hybrid":
+            retrieval_chunks = _merge_retrieval_chunks(semantic_chunks, lexical_chunks)
+        else:
+            retrieval_chunks = lexical_chunks
+
+        formatted_retrieval = format_retrieved_context(retrieval_chunks)
+
         chunks: list[str] = []
         chunk_count = 0
         char_count = 0
@@ -471,7 +587,7 @@ def stream_chat_workflow(req: ChatStreamRequest, route_path: str) -> Generator[d
             assignment_category=req.assignment_category or "",
             guide_markdown=req.guide_markdown,
             chat_history=[item.model_dump() for item in req.chat_history],
-            retrieval_context=[item.model_dump() for item in req.retrieval_context],
+            retrieval_context_text=formatted_retrieval.text,
             user_message=req.user_message,
             include_thinking=req.thinking_mode,
             calendar_context=req.calendar_context.model_dump() if req.calendar_context else None,
@@ -526,6 +642,7 @@ def stream_chat_workflow(req: ChatStreamRequest, route_path: str) -> Generator[d
             "stage": "completed",
             "progress_percent": 100,
             "status_message": "Response ready",
+            "sources": _serialize_sources(formatted_retrieval.sources),
         }
         thinking_content = "".join(reasoning_chunks).strip()
         if thinking_content:

--- a/agent_service/tests/unit/test_rag_context_formatter.py
+++ b/agent_service/tests/unit/test_rag_context_formatter.py
@@ -1,0 +1,60 @@
+import unittest
+from uuid import UUID
+
+from app.schemas.rag import RetrievedChunk
+from app.services.rag_context_formatter import format_retrieved_context
+
+
+def _chunk(index: int, source_type: str, text: str, similarity: float = 0.9, metadata=None):
+    return RetrievedChunk(
+        chunk_id=UUID(f"00000000-0000-0000-0000-{index:012d}"),
+        document_id=UUID(f"11111111-1111-1111-1111-{index:012d}"),
+        source_type=source_type,
+        source_id=f"source-{index}",
+        text=text,
+        metadata=metadata or {},
+        similarity=similarity,
+    )
+
+
+class TestRagContextFormatter(unittest.TestCase):
+    def test_formats_labeled_metadata_blocks(self):
+        result = format_retrieved_context(
+            [
+                _chunk(
+                    1,
+                    "guide_markdown",
+                    "Follow the implementation milestones.",
+                    metadata={"heading": "Implementation Plan"},
+                ),
+                _chunk(
+                    2,
+                    "assignment_pdf",
+                    "Submit the lab report as a PDF.",
+                    metadata={"filename": "Lab4.pdf", "page_number": 3, "extraction_method": "hybrid"},
+                ),
+            ],
+        )
+
+        self.assertIn('[A | guide_markdown | section="Implementation Plan"]', result.text)
+        self.assertIn('[B | assignment_pdf | file="Lab4.pdf" | page=3 | method=hybrid]', result.text)
+        self.assertEqual([source.label for source in result.sources], ["A", "B"])
+
+    def test_budget_drops_lowest_scoring_chunks_first(self):
+        result = format_retrieved_context(
+            [
+                _chunk(1, "guide_markdown", "High value context " * 10, similarity=0.9),
+                _chunk(2, "rubric", "Low value context " * 10, similarity=0.1),
+                _chunk(3, "assignment_payload", "Medium value context " * 10, similarity=0.5),
+            ],
+            char_budget=520,
+        )
+
+        self.assertIn("High value context", result.text)
+        self.assertIn("Medium value context", result.text)
+        self.assertNotIn("Low value context", result.text)
+        self.assertEqual([source.source_type for source in result.sources], ["guide_markdown", "assignment_payload"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_service/tests/unit/test_rag_retrieval_service.py
+++ b/agent_service/tests/unit/test_rag_retrieval_service.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch
+from uuid import UUID
+
+from app.services import rag_retrieval_service as svc
+
+USER_ID = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+ASSIGNMENT_UUID = UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+def _row(index: int, source_type: str, text: str | None = None) -> dict:
+    return {
+        "chunk_id": f"00000000-0000-0000-0000-{index:012d}",
+        "document_id": f"11111111-1111-1111-1111-{index:012d}",
+        "source_type": source_type,
+        "source_id": f"source-{index}",
+        "text": text or f"{source_type} chunk {index}",
+        "metadata": {},
+        "similarity": 1.0 - (index * 0.001),
+    }
+
+
+class TestRagRetrievalService(unittest.TestCase):
+    def test_per_source_caps_are_respected(self):
+        rows = (
+            [_row(i, "assignment_pdf") for i in range(1, 10)]
+            + [_row(i, "guide_markdown") for i in range(10, 16)]
+            + [_row(i, "rubric") for i in range(16, 21)]
+            + [_row(i, "assignment_payload") for i in range(21, 25)]
+            + [_row(i, "user_upload_pdf") for i in range(25, 31)]
+        )
+
+        with patch.dict("os.environ", {"MMR_SIMILARITY_THRESHOLD": "1.1"}), patch(
+            "app.services.rag_retrieval_service.embedding_client",
+        ) as mock_emb, patch(
+            "app.services.rag_retrieval_service.supabase_client",
+        ) as mock_sb:
+            mock_emb.embed_query.return_value = [1.0, 0.0]
+            mock_emb.embed_documents.return_value = [[1.0, float(i)] for i in range(len(rows))]
+            mock_sb.match_rag_chunks.return_value = rows
+
+            result = svc.retrieve("rubric details", USER_ID, ASSIGNMENT_UUID, top_k=50)
+
+        counts: dict[str, int] = {}
+        for chunk in result:
+            key = "user_upload" if chunk.source_type.startswith("user_upload") else chunk.source_type
+            counts[key] = counts.get(key, 0) + 1
+
+        self.assertEqual(counts["assignment_pdf"], 6)
+        self.assertEqual(counts["guide_markdown"], 4)
+        self.assertEqual(counts["rubric"], 3)
+        self.assertEqual(counts["assignment_payload"], 2)
+        self.assertEqual(counts["user_upload"], 4)
+
+    def test_mmr_removes_near_duplicate_chunks(self):
+        rows = [
+            _row(1, "guide_markdown", "same guide text"),
+            _row(2, "guide_markdown", "same guide text with tiny change"),
+            _row(3, "rubric", "different rubric text"),
+        ]
+
+        with patch("app.services.rag_retrieval_service.embedding_client") as mock_emb, patch(
+            "app.services.rag_retrieval_service.supabase_client",
+        ) as mock_sb:
+            mock_emb.embed_query.return_value = [1.0, 0.0]
+            mock_emb.embed_documents.return_value = [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]]
+            mock_sb.match_rag_chunks.return_value = rows
+
+            result = svc.retrieve("guide", USER_ID, ASSIGNMENT_UUID, top_k=10)
+
+        self.assertEqual([chunk.source_id for chunk in result], ["source-1", "source-3"])
+
+    def test_empty_rpc_results_return_empty_list(self):
+        with patch("app.services.rag_retrieval_service.embedding_client") as mock_emb, patch(
+            "app.services.rag_retrieval_service.supabase_client",
+        ) as mock_sb:
+            mock_emb.embed_query.return_value = [1.0, 0.0]
+            mock_sb.match_rag_chunks.return_value = []
+
+            result = svc.retrieve("missing topic", USER_ID, ASSIGNMENT_UUID)
+
+        self.assertEqual(result, [])
+        mock_emb.embed_documents.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_service/tests/unit/test_run_agent_service.py
+++ b/agent_service/tests/unit/test_run_agent_service.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
+from uuid import UUID
 
+from app.schemas.rag import RetrievedChunk
 from app.schemas.requests import ChatStreamRequest, RunAgentRequest
 from app.services.run_agent_service import (
     run_agent_workflow,
@@ -11,6 +13,18 @@ from app.services.run_agent_service import (
 SAMPLE_RESULT = {
     "guideMarkdown": "## Assignment Overview\n\nWrite a concise draft.",
 }
+
+
+def _retrieved_chunk(index: int, source_type: str, text: str, similarity: float = 0.9):
+    return RetrievedChunk(
+        chunk_id=UUID(f"00000000-0000-0000-0000-{index:012d}"),
+        document_id=UUID(f"11111111-1111-1111-1111-{index:012d}"),
+        source_type=source_type,
+        source_id=f"source-{index}",
+        text=text,
+        metadata={},
+        similarity=similarity,
+    )
 
 
 class TestRunAgentService(unittest.TestCase):
@@ -156,7 +170,7 @@ class TestRunAgentService(unittest.TestCase):
             assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
-            retrieval_context=[],
+            retrieval_context_text="(none)",
             user_message="What should I do first?",
             include_thinking=False,
             calendar_context=None,
@@ -202,7 +216,7 @@ class TestRunAgentService(unittest.TestCase):
             assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
-            retrieval_context=[],
+            retrieval_context_text="(none)",
             user_message="Use thinking mode",
             include_thinking=True,
             calendar_context=None,
@@ -265,7 +279,7 @@ class TestRunAgentService(unittest.TestCase):
             assignment_category="",
             guide_markdown="Guide body",
             chat_history=[],
-            retrieval_context=[],
+            retrieval_context_text="(none)",
             user_message="Schedule time blocks for me",
             include_thinking=False,
             calendar_context={
@@ -328,7 +342,7 @@ class TestRunAgentService(unittest.TestCase):
             assignment_category="mathematics",
             guide_markdown="Guide body",
             chat_history=[],
-            retrieval_context=[],
+            retrieval_context_text="(none)",
             user_message="How should I start?",
             include_thinking=False,
             calendar_context=None,
@@ -403,6 +417,117 @@ class TestRunAgentService(unittest.TestCase):
             no_slots_review.calendar_context.availability_reason,  # type: ignore[union-attr]
             "no_slots_in_review_window",
         )
+
+    def test_stream_chat_workflow_semantic_mode_uses_semantic_context(self):
+        req = ChatStreamRequest(
+            assignment_payload={"title": "HW1"},
+            guide_markdown="Guide body",
+            chat_history=[],
+            retrieval_context=[
+                {
+                    "chunk_id": "legacy-1",
+                    "source": "guide_markdown",
+                    "text": "Legacy lexical context",
+                    "score": 0.4,
+                }
+            ],
+            user_id="aaaaaaaa-0000-0000-0000-000000000001",
+            assignment_uuid="bbbbbbbb-0000-0000-0000-000000000002",
+            retrieval_mode="semantic",
+            user_message="What does the rubric require?",
+        )
+        semantic = [_retrieved_chunk(1, "rubric", "Semantic rubric context")]
+
+        with patch(
+            "app.services.run_agent_service.retrieve_rag_chunks",
+            return_value=semantic,
+        ), patch(
+            "app.services.run_agent_service._stream_headstart_chat_answer",
+            return_value=iter([{"content_delta": "Use the rubric.", "reasoning_delta": ""}]),
+        ) as mock_stream:
+            events = list(stream_chat_workflow(req, route_path="/api/v1/chats/stream"))
+
+        context = mock_stream.call_args.kwargs["retrieval_context_text"]
+        self.assertIn("Semantic rubric context", context)
+        self.assertNotIn("Legacy lexical context", context)
+        completed = [event for event in events if event.get("event") == "chat.completed"][0]["data"]
+        self.assertEqual(completed["sources"][0]["source_type"], "rubric")
+        self.assertEqual(completed["sources"][0]["label"], "A")
+
+    def test_stream_chat_workflow_hybrid_mode_merges_and_deduplicates(self):
+        req = ChatStreamRequest(
+            assignment_payload={"title": "HW1"},
+            guide_markdown="Guide body",
+            chat_history=[],
+            retrieval_context=[
+                {
+                    "chunk_id": "legacy-1",
+                    "source": "guide_markdown",
+                    "text": "Semantic guide context",
+                    "score": 0.8,
+                },
+                {
+                    "chunk_id": "legacy-2",
+                    "source": "assignment_payload",
+                    "text": "Unique lexical payload context",
+                    "score": 0.6,
+                },
+            ],
+            user_id="aaaaaaaa-0000-0000-0000-000000000001",
+            assignment_uuid="bbbbbbbb-0000-0000-0000-000000000002",
+            retrieval_mode="hybrid",
+            user_message="What should I do?",
+        )
+        semantic = [_retrieved_chunk(1, "guide_markdown", "Semantic guide context")]
+
+        with patch(
+            "app.services.run_agent_service.retrieve_rag_chunks",
+            return_value=semantic,
+        ), patch(
+            "app.services.run_agent_service._stream_headstart_chat_answer",
+            return_value=iter([{"content_delta": "Start here.", "reasoning_delta": ""}]),
+        ) as mock_stream:
+            events = list(stream_chat_workflow(req, route_path="/api/v1/chats/stream"))
+
+        context = mock_stream.call_args.kwargs["retrieval_context_text"]
+        self.assertEqual(context.count("Semantic guide context"), 1)
+        self.assertIn("Unique lexical payload context", context)
+        completed = [event for event in events if event.get("event") == "chat.completed"][0]["data"]
+        self.assertEqual(len(completed["sources"]), 2)
+
+    def test_stream_chat_workflow_retrieval_exception_warns_and_uses_lexical(self):
+        req = ChatStreamRequest(
+            assignment_payload={"title": "HW1"},
+            guide_markdown="Guide body",
+            chat_history=[],
+            retrieval_context=[
+                {
+                    "chunk_id": "legacy-1",
+                    "source": "guide_markdown",
+                    "text": "Fallback lexical context",
+                    "score": 0.7,
+                }
+            ],
+            user_id="aaaaaaaa-0000-0000-0000-000000000001",
+            assignment_uuid="bbbbbbbb-0000-0000-0000-000000000002",
+            retrieval_mode="hybrid",
+            user_message="What should I do?",
+        )
+
+        with patch(
+            "app.services.run_agent_service.retrieve_rag_chunks",
+            side_effect=RuntimeError("index unavailable"),
+        ), patch(
+            "app.services.run_agent_service._stream_headstart_chat_answer",
+            return_value=iter([{"content_delta": "Use fallback.", "reasoning_delta": ""}]),
+        ) as mock_stream:
+            events = list(stream_chat_workflow(req, route_path="/api/v1/chats/stream"))
+
+        warning_events = [event for event in events if event.get("event") == "chat.retrieval_warning"]
+        self.assertEqual(len(warning_events), 1)
+        self.assertIn("index unavailable", warning_events[0]["data"]["message"])
+        context = mock_stream.call_args.kwargs["retrieval_context_text"]
+        self.assertIn("Fallback lexical context", context)
 
 
 if __name__ == "__main__":

--- a/agent_service/tests/unit/test_supabase_client.py
+++ b/agent_service/tests/unit/test_supabase_client.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from app.clients import supabase_client
+
+
+class TestSupabaseClient(unittest.TestCase):
+    def test_bulk_insert_rag_chunks_accepts_empty_minimal_response(self):
+        response = Mock()
+        response.content = b""
+        response.raise_for_status.return_value = None
+
+        with patch.dict(
+            "os.environ",
+            {
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_SERVICE_ROLE_KEY": "service-role",
+            },
+        ), patch("app.clients.supabase_client.httpx.post", return_value=response):
+            result = supabase_client.bulk_insert_rag_chunks(
+                [
+                    {
+                        "document_id": "doc-1",
+                        "user_id": "user-1",
+                        "assignment_uuid": "assignment-1",
+                        "source_type": "guide_markdown",
+                        "source_id": "guide-1",
+                        "chunk_index": 0,
+                        "text": "Chunk text",
+                        "content_hash": "hash-1",
+                        "embedding": [0.1, 0.2],
+                        "metadata": {},
+                    }
+                ]
+            )
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/src/lib/chat-session-runner.ts
+++ b/webapp/src/lib/chat-session-runner.ts
@@ -38,6 +38,7 @@ type AgentRunEventName =
 
 type AgentChatEventName =
   | "chat.started"
+  | "chat.retrieval_warning"
   | "chat.delta"
   | "chat.completed"
   | "chat.error"
@@ -727,6 +728,9 @@ async function runFollowupChat(input: {
         guide_markdown: sessionContext.guideMarkdown,
         chat_history: chatHistory,
         retrieval_context: retrievalContext,
+        user_id: sessionContext.userId,
+        assignment_uuid: sessionContext.assignmentUuid,
+        retrieval_mode: "hybrid",
         user_message: userMessageContent,
         thinking_mode: false,
         calendar_context: calendarContext,
@@ -762,6 +766,11 @@ async function runFollowupChat(input: {
               ? data.status_message
               : "Generating follow-up response",
         });
+        continue;
+      }
+
+      if (event === "chat.retrieval_warning") {
+        console.warn("[chat-runner] Semantic retrieval warning:", data.message ?? data);
         continue;
       }
 
@@ -830,6 +839,7 @@ async function runFollowupChat(input: {
         assistantContent = assistantContent
           .replace(/<calendar_proposal>[\s\S]*?<\/calendar_proposal>/g, "")
           .trim();
+        const sources = Array.isArray(data.sources) ? data.sources : [];
 
         await updateChatMessageContent({
           messageId: assistantMessageId,
@@ -837,6 +847,7 @@ async function runFollowupChat(input: {
           metadata: {
             streaming: false,
             completed: true,
+            ...(sources.length > 0 ? { sources } : {}),
             ...(firstProposal ? { calendar_proposal: firstProposal } : {}),
           },
         });
@@ -1026,6 +1037,9 @@ async function runGuideRegeneration(input: {
         guide_markdown: sessionContext.guideMarkdown,
         chat_history: chatHistory,
         retrieval_context: retrievalContext,
+        user_id: userId,
+        assignment_uuid: assignmentUuid,
+        retrieval_mode: "hybrid",
         user_message: regenerationInstruction,
         thinking_mode: false,
         // Omit calendar_context entirely — guide updates should not include scheduling
@@ -1055,6 +1069,11 @@ async function runGuideRegeneration(input: {
           progressPercent: toPercent(data.progress_percent, 97),
           statusMessage: `Updating guide (v${versionNumber})`,
         });
+        continue;
+      }
+
+      if (event === "chat.retrieval_warning") {
+        console.warn("[chat-runner] Semantic retrieval warning during guide update:", data.message ?? data);
         continue;
       }
 


### PR DESCRIPTION
## Summary
- add agent-side RAG retrieval and labeled context formatting
- wire semantic/hybrid retrieval into follow-up chat streams with warning fallback and sources payloads
- send user/assignment scope from the webapp and persist completed response sources
- handle empty PostgREST return=minimal responses during RAG chunk inserts

Closes #73

## Tests
- cd agent_service && ./myenv/bin/python -m pytest
- cd webapp && npm run lint
- cd webapp && npm run build