### PR TITLE
Add retrieval evaluation tests and configuration

### DIFF
--- a/agent_service/pytest.ini
+++ b/agent_service/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -m "not eval"
+markers =
+    eval: live retrieval evaluation tests that require staging Supabase and NVIDIA credentials

--- a/agent_service/tests/eval/README.md
+++ b/agent_service/tests/eval/README.md
@@ -1,0 +1,30 @@
+# Retrieval Eval Harness
+
+These tests measure live RAG retrieval quality against a pre-indexed staging
+assignment. They are marked `eval` and excluded from the default test run.
+
+## Required Environment
+
+- `EVAL_USER_ID` - UUID of the seeded staging user.
+- `EVAL_ASSIGNMENT_UUID` - UUID of the pre-indexed staging assignment.
+- `SUPABASE_URL` - staging Supabase URL.
+- `SUPABASE_SERVICE_ROLE_KEY` - staging service-role key.
+- `NVIDIA_API_KEY` - NVIDIA API key for query embeddings.
+- `NVIDIA_EMBEDDING_MODEL` - optional; defaults to the app embedding model.
+
+The staging assignment should have indexed chunks for assignment payload, rubric,
+guide markdown, and at least one assignment PDF.
+
+## Run
+
+```bash
+cd agent_service
+EVAL_USER_ID=... EVAL_ASSIGNMENT_UUID=... ./myenv/bin/python -m pytest -m eval
+```
+
+Default unit tests remain offline:
+
+```bash
+cd agent_service
+./myenv/bin/python -m pytest
+```

--- a/agent_service/tests/eval/__init__.py
+++ b/agent_service/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Live retrieval evaluation tests."""

--- a/agent_service/tests/eval/conftest.py
+++ b/agent_service/tests/eval/conftest.py
@@ -1,0 +1,65 @@
+import json
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+EVAL_ENV_VARS = [
+    "EVAL_USER_ID",
+    "EVAL_ASSIGNMENT_UUID",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "NVIDIA_API_KEY",
+]
+
+
+def _is_explicit_eval_run(config: pytest.Config) -> bool:
+    markexpr = str(config.getoption("-m") or "")
+    return "eval" in markexpr and "not eval" not in markexpr
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if _is_explicit_eval_run(config):
+        return
+
+    skip_eval = pytest.mark.skip(reason="eval tests require pytest -m eval and staging env")
+    for item in items:
+        if "eval" in item.keywords:
+            item.add_marker(skip_eval)
+
+
+@pytest.fixture(scope="session")
+def eval_user_id() -> UUID:
+    return UUID(os.environ["EVAL_USER_ID"])
+
+
+@pytest.fixture(scope="session")
+def eval_assignment_uuid() -> UUID:
+    return UUID(os.environ["EVAL_ASSIGNMENT_UUID"])
+
+
+@pytest.fixture(scope="session")
+def eval_cases() -> list[dict[str, Any]]:
+    path = FIXTURES_DIR / "eval_cases.json"
+    with path.open("r", encoding="utf-8") as f:
+        cases = json.load(f)
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("eval_cases.json must contain a non-empty list")
+    return cases
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_eval_environment(request: pytest.FixtureRequest) -> None:
+    if not _is_explicit_eval_run(request.config):
+        return
+
+    missing = [name for name in EVAL_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        pytest.fail(
+            "Missing eval environment variables: "
+            + ", ".join(missing)
+            + ". See tests/eval/README.md."
+        )

--- a/agent_service/tests/eval/fixtures/eval_cases.json
+++ b/agent_service/tests/eval/fixtures/eval_cases.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "rubric_expectations",
+    "category": "rubric",
+    "query": "What does the grading rubric emphasize most for this assignment?",
+    "expected_source_type": "rubric",
+    "expected_keywords": ["rubric", "criteria", "points"]
+  },
+  {
+    "id": "planning_due_date",
+    "category": "assignment_payload",
+    "query": "When is this due and what should I plan first?",
+    "expected_source_type": "assignment_payload",
+    "expected_keywords": ["due", "date", "title"]
+  },
+  {
+    "id": "pdf_specific_requirement",
+    "category": "assignment_pdf",
+    "query": "What requirement appears in the assignment PDF instructions?",
+    "expected_source_type": "assignment_pdf",
+    "expected_keywords": ["submit", "report", "pdf"]
+  },
+  {
+    "id": "vague_next_step",
+    "category": "vague",
+    "query": "What should I focus on next?",
+    "expected_source_type": null,
+    "expected_keywords": []
+  },
+  {
+    "id": "guide_specific_milestones",
+    "category": "guide_markdown",
+    "query": "What milestones does the generated study guide recommend?",
+    "expected_source_type": "guide_markdown",
+    "expected_keywords": ["milestone", "study", "plan"]
+  }
+]

--- a/agent_service/tests/eval/test_retrieval_eval.py
+++ b/agent_service/tests/eval/test_retrieval_eval.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import pytest
+
+from app.schemas.rag import RetrievedChunk
+from app.services.rag_retrieval_service import retrieve
+
+RECALL_AT_5_THRESHOLD = 0.6
+SOURCE_TYPE_ACCURACY_THRESHOLD = 0.8
+
+
+def _normalize_keywords(case: dict[str, Any]) -> list[str]:
+    keywords = case.get("expected_keywords") or []
+    if not isinstance(keywords, list):
+        return []
+    return [str(keyword).lower() for keyword in keywords if str(keyword).strip()]
+
+
+def _has_keyword_hit(chunk: RetrievedChunk, keywords: list[str]) -> bool:
+    if not keywords:
+        return True
+    text = f"{chunk.text} {chunk.source_type} {chunk.source_id}".lower()
+    return any(keyword in text for keyword in keywords)
+
+
+def _first_hit_rank(chunks: list[RetrievedChunk], keywords: list[str]) -> int | None:
+    for rank, chunk in enumerate(chunks, start=1):
+        if _has_keyword_hit(chunk, keywords):
+            return rank
+    return None
+
+
+def _source_type_hit(chunks: list[RetrievedChunk], expected_source_type: str | None) -> bool:
+    if not expected_source_type:
+        return bool(chunks)
+    top_5 = chunks[:5]
+    return any(chunk.source_type == expected_source_type for chunk in top_5)
+
+
+@pytest.mark.eval
+def test_retrieval_quality(eval_user_id, eval_assignment_uuid, eval_cases, capsys):
+    rows: list[dict[str, Any]] = []
+
+    for case in eval_cases:
+        query = str(case["query"])
+        expected_source_type = case.get("expected_source_type")
+        if expected_source_type is not None:
+            expected_source_type = str(expected_source_type)
+        keywords = _normalize_keywords(case)
+
+        chunks = retrieve(
+            query=query,
+            user_id=eval_user_id,
+            assignment_uuid=eval_assignment_uuid,
+            top_k=10,
+        )
+        first_rank = _first_hit_rank(chunks, keywords)
+        rows.append(
+            {
+                "id": case.get("id", query),
+                "retrieved": len(chunks),
+                "recall_at_5": first_rank is not None and first_rank <= 5,
+                "recall_at_10": first_rank is not None and first_rank <= 10,
+                "mrr": 0.0 if first_rank is None else 1.0 / first_rank,
+                "source_type_hit": _source_type_hit(chunks, expected_source_type),
+                "top_sources": [chunk.source_type for chunk in chunks[:5]],
+            }
+        )
+
+    recall_at_5 = sum(1 for row in rows if row["recall_at_5"]) / len(rows)
+    recall_at_10 = sum(1 for row in rows if row["recall_at_10"]) / len(rows)
+    mrr = sum(float(row["mrr"]) for row in rows) / len(rows)
+    source_type_cases = [row for row, case in zip(rows, eval_cases) if case.get("expected_source_type")]
+    source_type_accuracy = (
+        sum(1 for row in source_type_cases if row["source_type_hit"]) / len(source_type_cases)
+        if source_type_cases
+        else 1.0
+    )
+
+    print("\nRAG retrieval eval")
+    print(f"cases={len(rows)}")
+    print(f"recall@5={recall_at_5:.3f}")
+    print(f"recall@10={recall_at_10:.3f}")
+    print(f"mrr={mrr:.3f}")
+    print(f"source_type_accuracy={source_type_accuracy:.3f}")
+    for row in rows:
+        print(
+            f"- {row['id']}: retrieved={row['retrieved']} "
+            f"r@5={row['recall_at_5']} r@10={row['recall_at_10']} "
+            f"mrr={row['mrr']:.3f} source_hit={row['source_type_hit']} "
+            f"top_sources={row['top_sources']}"
+        )
+
+    captured = capsys.readouterr()
+    print(captured.out)
+
+    assert recall_at_5 >= RECALL_AT_5_THRESHOLD
+    assert source_type_accuracy >= SOURCE_TYPE_ACCURACY_THRESHOLD


### PR DESCRIPTION
This pull request introduces a new live retrieval evaluation harness for the agent service, enabling automated testing of RAG (Retrieval-Augmented Generation) retrieval quality in a staging environment. The new tests are isolated from the default test suite, require specific environment variables, and provide metrics such as recall@5, recall@10, mean reciprocal rank (MRR), and source type accuracy.

**Retrieval Evaluation Harness**

* Added a new `eval` test suite for live RAG retrieval evaluation, including a pytest marker and configuration to exclude these tests from the default run. [[1]](diffhunk://#diff-6610d65f03a34ff5dbb59b8b68cb362ccaf76797e27312c2305f7fa6d5036cd1R1-R4) [[2]](diffhunk://#diff-a2090a41c1dfda68c58c6435384355208c61154f2ccb54efec1122c6aee6e0b7R1)
* Created a detailed README (`tests/eval/README.md`) with instructions for running the eval suite, required environment variables, and test setup.
* Added a sample fixture file (`eval_cases.json`) defining evaluation cases with queries, expected source types, and keywords.

**Test Infrastructure and Logic**

* Implemented a `conftest.py` to manage eval-specific pytest fixtures, environment validation, and logic to skip eval tests unless explicitly requested and properly configured.
* Added the main retrieval evaluation test (`test_retrieval_eval.py`) that loads cases, runs retrieval, computes metrics (recall@5, recall@10, MRR, source type accuracy), prints a summary, and enforces minimum thresholds.